### PR TITLE
fix(@angular-devkit/devkit): fix incorrect implementation of schematic interface

### DIFF
--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -101,7 +101,7 @@ export interface Schematic<CollectionMetadataT extends object, SchematicMetadata
   readonly description: SchematicDescription<CollectionMetadataT, SchematicMetadataT>;
   readonly collection: Collection<CollectionMetadataT, SchematicMetadataT>;
 
-  call<T>(options: T, host: Observable<Tree>): Observable<Tree>;
+  call<OptionT extends object>(options: OptionT, host: Observable<Tree>): Observable<Tree>;
 }
 
 

--- a/packages/angular_devkit/schematics/src/rules/schematic.ts
+++ b/packages/angular_devkit/schematics/src/rules/schematic.ts
@@ -18,9 +18,9 @@ import { branch } from '../tree/static';
  * @param schematicName The name of the schematic to run.
  * @param options The options to pass as input to the RuleFactory.
  */
-export function externalSchematic<T>(collectionName: string,
-                                     schematicName: string,
-                                     options: T): Rule {
+export function externalSchematic<OptionT extends object>(collectionName: string,
+                                                          schematicName: string,
+                                                          options: OptionT): Rule {
   return (input: Tree, context: SchematicContext) => {
     const collection = context.engine.createCollection(collectionName);
     const schematic = collection.createSchematic(schematicName);
@@ -36,7 +36,7 @@ export function externalSchematic<T>(collectionName: string,
  * @param schematicName The name of the schematic to run.
  * @param options The options to pass as input to the RuleFactory.
  */
-export function schematic<T>(schematicName: string, options: T): Rule {
+export function schematic<OptionT extends object>(schematicName: string, options: OptionT): Rule {
   return (input: Tree, context: SchematicContext) => {
     const collection = context.schematic.collection;
     const schematic = collection.createSchematic(schematicName);


### PR DESCRIPTION
fix the SchematicImpl class incorrectly implementing the Schematic interface

resolve issue #75