### PR TITLE
fix(@angular-devkit/build-optimizer): add cdk to angular whitelist

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -31,6 +31,7 @@ const whitelistedAngularModules = [
   /(\\|\/)node_modules(\\|\/)@angular(\\|\/)router(\\|\/)/,
   /(\\|\/)node_modules(\\|\/)@angular(\\|\/)upgrade(\\|\/)/,
   /(\\|\/)node_modules(\\|\/)@angular(\\|\/)material(\\|\/)/,
+  /(\\|\/)node_modules(\\|\/)@angular(\\|\/)cdk(\\|\/)/,
 ];
 
 export interface BuildOptimizerOptions {


### PR DESCRIPTION
The `@angular/cdk` package should be included in the Angular whitelist to avoid size regression in AIO.