### PR TITLE
fix(@schematics/angular): 2 fixes

### DIFF
--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -64,7 +64,9 @@ function addDeclarationToNgModule(options: GuardOptions): Rule {
 
 export default function (options: GuardOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
-    options.module = findModuleFromOptions(host, options);
+    if (options.module) {
+      options.module = findModuleFromOptions(host, options);
+    }
 
     const templateSource = apply(url('./files'), [
       options.spec ? noop() : filter(path => !path.endsWith('.spec.ts')),

--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -35,12 +35,15 @@ export function findModuleFromOptions(host: Tree,
     return normalizePath(findModule(host, pathToCheck));
   } else {
     const modulePath = options.sourceDir + '/' + options.path + '/' + options.module;
+    const moduleBaseName = options.module.split('/').pop();
     if (host.exists(modulePath)) {
       return normalizePath(modulePath);
     } else if (host.exists(modulePath + '.ts')) {
       return normalizePath(modulePath + '.ts');
     } else if (host.exists(modulePath + '.module.ts')) {
       return normalizePath(modulePath + '.module.ts');
+    } else if (host.exists(modulePath + '/' + moduleBaseName + '.module.ts')) {
+      return normalizePath(modulePath + '/' + moduleBaseName + '.module.ts');
     } else {
       throw new Error('Specified module does not exist');
     }


### PR DESCRIPTION
1. when not passing --module, guard should not try to import it
2. fix regression with --module logic, which allows to pass a path