### PR TITLE
build(@angular/cli): ignore vim and emacs files

### DIFF
--- a/packages/schematics/angular/application/files/__dot__angular-cli.json
+++ b/packages/schematics/angular/application/files/__dot__angular-cli.json
@@ -51,6 +51,9 @@
     }
   },
   "defaults": {
+    "build": {
+      "ignored": ["**/*~", "**/.#*", "**/.*.sw[pon]"]
+    },
     "styleExt": "<%= style %>",<% if (!minimal) { %>
     "component": {}<% } else { %>
     "component": {


### PR DESCRIPTION
Change the default `build.ignored` option to ignore
files used by vim and emacs that are not needed by
angular-cli

This depends on changes from angular/angular-cli#7448