### PR TITLE
Add --open parameter to start script

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --open",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
This causes executing the start script to open the angular
app automatically.