### PR TITLE
fix(build-optimizer): remove restriction to *.es5.js

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -15,7 +15,6 @@ import { getScrubFileTransformer, testScrubFile } from '../transforms/scrub-file
 import { getWrapEnumsTransformer, testWrapEnums } from '../transforms/wrap-enums';
 
 
-const isAngularModuleFile = /\.es5\.js$/;
 const whitelistedAngularModules = [
   /(\\|\/)node_modules(\\|\/)@angular(\\|\/)animations(\\|\/)/,
   /(\\|\/)node_modules(\\|\/)@angular(\\|\/)common(\\|\/)/,
@@ -70,7 +69,6 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
   }
 
   if (inputFilePath
-    && isAngularModuleFile.test(inputFilePath)
     && whitelistedAngularModules.some((re) => re.test(inputFilePath))
   ) {
     getTransforms.push(

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -112,7 +112,7 @@ describe('build-optimizer', () => {
     });
 
     it('should not process non-whitelisted umd modules', () => {
-      const inputFilePath = '/node_modules/@angular/core/bundles/core.umd.js';
+      const inputFilePath = '/node_modules/other_lib/index.js';
       const boOutput = buildOptimizer({ content: input, inputFilePath });
       expect(boOutput.emitSkipped).toEqual(true);
     });


### PR DESCRIPTION
When this library was first created it was restricted to FESM5 files (`*.es5.js`) and the Angular package directories were hard-coded. We are moving things around and so the restrictions are being loosened to include everything in the `@angular` directory.

This will eventually go away when we support reading the pure imports from package.json.