### PR TITLE
fix(@angular-devkit/schematics): fix node_modules and .git filtering

### DIFF
--- a/packages/angular_devkit/schematics/tools/file-system-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-host.ts
@@ -14,7 +14,7 @@ export class FileSystemHost implements FileSystemTreeHost {
 
   listDirectory(path: string) {
     let files = readdirSync(join(this._root, path));
-    if (path == '/') {
+    if (path == '/' || path == '') {
       files = files
       // Remove .git.
         .filter(path => path !== '.git')


### PR DESCRIPTION
It was not working because the first path is "", not "/".