### PR TITLE
Fix the filter for ngo's purify webpack plugin

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
@@ -21,7 +21,7 @@ export class PurifyPlugin {
       compilation.plugin('optimize-chunk-assets', (chunks: Chunk[], callback: () => void) => {
         chunks.forEach((chunk: Chunk) => {
           chunk.files
-            .filter((fileName: string) => fileName.endsWith('.bundle.js'))
+            .filter((fileName: string) => fileName.endsWith('.js'))
             .forEach((fileName: string) => {
               const purifiedSource = purify(compilation.assets[fileName].source());
               compilation.assets[fileName]._cachedSource = purifiedSource;


### PR DESCRIPTION
This PR fixes the filter in the NGO purify plugin to include files that end in .js instead of .bundle.js.

I discussed this PR with @filipesilva on slack.

Thanks,
Dan