### PR TITLE
fix(@angular/devkit-build-optimizer): Support disabled module caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "ts-node": "^2.0.0",
     "tslint": "^5.5.0",
     "typescript": "~2.3.0",
-    "v8-profiler": "^5.7.0"
+    "v8-profiler": "^5.7.0",
+    "webpack-sources": "^1.0.1"
   },
   "devDependencies": {
     "protobufjs": "5.0.0"

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "loader-utils": "^1.1.0",
     "source-map": "^0.5.6",
-    "typescript": "^2.3.3"
+    "typescript": "^2.3.3",
+    "webpack-sources": "^1.0.1"
   }
 }

--- a/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
@@ -6,6 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as webpack from 'webpack';
+import { ConcatSource } from 'webpack-sources';
 import { purify } from './purify';
 
 
@@ -24,8 +25,13 @@ export class PurifyPlugin {
             .filter((fileName: string) => fileName.endsWith('.js'))
             .forEach((fileName: string) => {
               const purifiedSource = purify(compilation.assets[fileName].source());
-              compilation.assets[fileName]._cachedSource = purifiedSource;
-              compilation.assets[fileName]._source.source = () => purifiedSource;
+              if(compilation.assets[fileName] instanceof ConcatSource) {
+                compilation.assets[fileName] = new ConcatSource(purifiedSource)
+              }
+              else {
+                compilation.assets[fileName]._cachedSource = purifiedSource;
+                compilation.assets[fileName]._source.source = () => purifiedSource;
+              }
             });
         });
         callback();

--- a/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
@@ -6,7 +6,7 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import * as webpack from 'webpack';
-import { ConcatSource } from 'webpack-sources';
+import { CachedSource, ConcatSource, RawSource } from 'webpack-sources';
 import { purify } from './purify';
 
 
@@ -28,8 +28,7 @@ export class PurifyPlugin {
               if (compilation.assets[fileName] instanceof ConcatSource) {
                 compilation.assets[fileName] = new ConcatSource(purifiedSource);
               } else {
-                compilation.assets[fileName]._cachedSource = purifiedSource;
-                compilation.assets[fileName]._source.source = () => purifiedSource;
+                compilation.assets[fileName] = new CachedSource(new RawSource(purifiedSource));
               }
             });
         });

--- a/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
+++ b/packages/angular_devkit/build_optimizer/src/purify/webpack-plugin.ts
@@ -25,10 +25,9 @@ export class PurifyPlugin {
             .filter((fileName: string) => fileName.endsWith('.js'))
             .forEach((fileName: string) => {
               const purifiedSource = purify(compilation.assets[fileName].source());
-              if(compilation.assets[fileName] instanceof ConcatSource) {
-                compilation.assets[fileName] = new ConcatSource(purifiedSource)
-              }
-              else {
+              if (compilation.assets[fileName] instanceof ConcatSource) {
+                compilation.assets[fileName] = new ConcatSource(purifiedSource);
+              } else {
                 compilation.assets[fileName]._cachedSource = purifiedSource;
                 compilation.assets[fileName]._source.source = () => purifiedSource;
               }


### PR DESCRIPTION
Handles the different source type that webpack uses when caching is disabled (ConcatSource instead of CachedSource)