### PR TITLE
feat(@schematics/angular): remove codelyzer rules

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -135,8 +135,6 @@
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
     "directive-class-suffix": true,
-    "no-access-missing-member": true,
-    "templates-use-public": true,
     "invoke-injectable": true
   }
 }


### PR DESCRIPTION
It's a copy/paste of this [PR](https://github.com/angular/angular-cli/pull/6651) :


Few codelyzer rules report warnings which are also compile-time errors caught by the
Angular compiler and reported by the language service.

Since codelyzer doesn't aim to provide type checking and deep analysis
of the entire project, it'll be better if these two rules are removed.

Btw, soon more rules will follow mgechev/codelyzer#314.


cc/ @mgechev
