### PR TITLE
fix(@schematics/angular): fix missing link attribute for PWA

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.html
+++ b/packages/schematics/angular/application/other-files/app.component.html
@@ -8,13 +8,13 @@
 <h2>Here are some links to help you start: </h2>
 <ul>
   <li>
-    <h2><a target="_blank" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" href="https://blog.angular.io/">Angular blog</a></h2>
+    <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
 <% if (routing) { %>


### PR DESCRIPTION
This change fixes a security/performance issue in links that open in new windows, and by the same token, increases the lighthouse score for PWAs. Assuming we (eventually) want a CLI-generated Angular project to be 100% PWA, this is a necessary change.