### PR TITLE
fix(@schematics/angular): fix find module when using non-normalized paths

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -56,7 +56,7 @@ export function findModuleFromOptions(host: Tree,
  * Function to find the "closest" module to a generated file's path.
  */
 export function findModule(host: Tree, generateDir: string): SchematicPath {
-  let closestModule = generateDir;
+  let closestModule: string = normalizePath(generateDir.replace(/[\\/]$/, ''));
   const allFiles = host.files;
 
   let modulePath: string | null = null;

--- a/packages/schematics/angular/utility/find-module_spec.ts
+++ b/packages/schematics/angular/utility/find-module_spec.ts
@@ -36,6 +36,12 @@ describe('find-module', () => {
       expect(foundModule).toEqual(modulePath);
     });
 
+    it('should work with weird paths', () => {
+      host.create('/foo/src/app/app-routing.module.ts', 'app module');
+      const foundModule = findModule(host, 'foo//src//app/bar/');
+      expect(foundModule).toEqual(modulePath);
+    });
+
     it('should throw if no modules found', () => {
       host.create('/foo/src/app/oops.module.ts', 'app module');
       try {


### PR DESCRIPTION
Fixes https://github.com/angular/angular-cli/issues/7631