### PR TITLE
fix(@schematics/angular): fix application sourceDir option

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -28,9 +28,9 @@ import { InsertChange } from '../utility/change';
 import { Schema as ApplicationOptions } from './schema';
 
 
-function addBootstrapToNgModule(directory: string): Rule {
+function addBootstrapToNgModule(directory: string, sourceDir: string): Rule {
   return (host: Tree) => {
-    const modulePath = `${directory}/src/app/app.module.ts`;
+    const modulePath = `${directory}/${sourceDir}/app/app.module.ts`;
     const content = host.read(modulePath);
     if (!content) {
       throw new SchematicsError(`File ${modulePath} does not exist.`);
@@ -88,6 +88,7 @@ export default function (options: ApplicationOptions): Rule {
         spec: false,
         styleext: options.style,
       };
+    const sourceDir = options.sourceDir || 'src';
 
     return chain([
       mergeWith(
@@ -106,17 +107,17 @@ export default function (options: ApplicationOptions): Rule {
         flat: true,
         routing: options.routing,
         routingScope: 'Root',
-        sourceDir: options.directory + '/' + options.sourceDir,
+        sourceDir: options.directory + '/' + sourceDir,
         spec: false,
       }),
       schematic('component', {
         name: 'app',
         selector: appRootSelector,
-        sourceDir: options.directory + '/' + options.sourceDir,
+        sourceDir: options.directory + '/' + sourceDir,
         flat: true,
         ...componentOptions,
       }),
-      addBootstrapToNgModule(options.directory),
+      addBootstrapToNgModule(options.directory, sourceDir),
       mergeWith(
         apply(url('./other-files'), [
           componentOptions.inlineTemplate ? filter(path => !path.endsWith('.html')) : noop(),
@@ -127,7 +128,7 @@ export default function (options: ApplicationOptions): Rule {
             selector: appRootSelector,
             ...componentOptions,
           }),
-          move(options.directory + '/' + options.sourceDir + '/app'),
+          move(options.directory + '/' + sourceDir + '/app'),
         ]), MergeStrategy.Overwrite),
     ])(host, context);
   };

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import { getFileContent } from '../utility/test';
 import { Schema as AppSchema } from './schema';
@@ -62,6 +63,20 @@ describe('Application Schematic', () => {
     expect(files.indexOf('/foo/src/app/app.component.html')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/src/app/app.component.spec.ts')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/foo/src/app/app.component.ts')).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should handle a different sourceDir', () => {
+    const options = { ...defaultOptions, sourceDir: 'some/custom/path' };
+
+    let tree: Tree | null = null;
+    expect(() => tree = schematicRunner.runSchematic('application', options))
+      .not.toThrow();
+
+    if (tree) {
+      // tslint:disable-next-line:non-null-operator
+      const files = tree !.files;
+      expect(files.indexOf('/foo/some/custom/path/app/app.module.ts')).toBeGreaterThanOrEqual(0);
+    }
   });
 
   it('should handle the routing flag', () => {


### PR DESCRIPTION
There is a hard-coded sourceDir expectation in the code, this removes it
in favor of using the appropriate value from options.

Fixes https://github.com/angular/angular-cli/issues/7656