### PR TITLE
docs(@schematics/angular): fix wrong package name for animations

### DIFF
--- a/packages/schematics/angular/application/files/__path__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__path__/polyfills.ts
@@ -43,7 +43,7 @@ import 'core-js/es7/reflect';
 
 
 /**
- * Required to support Web Animations `@angular/animation`.
+ * Required to support Web Animations `@angular/platform-browser/animations`.
  * Needed for: All but Chrome, Firefox and Opera. http://caniuse.com/#feat=web-animation
  **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.


### PR DESCRIPTION
`@angular/animation` doesn't exist.