### PR TITLE
refactor: make schema aliases consistent

### DIFF
--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { getFileContent } from '../utility/test';
-import { Schema as AppSchema } from './schema';
+import { Schema as ApplicationOptions } from './schema';
 
 
 describe('Application Schematic', () => {
@@ -17,7 +17,7 @@ describe('Application Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: AppSchema = {
+  const defaultOptions: ApplicationOptions = {
     directory: 'foo',
     name: 'foo',
     path: 'src',

--- a/packages/schematics/angular/class/index_spec.ts
+++ b/packages/schematics/angular/class/index_spec.ts
@@ -8,7 +8,7 @@
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { getFileContent } from '../utility/test';
-import { Schema as ClassSchema } from './schema';
+import { Schema as ClassOptions } from './schema';
 
 
 describe('Class Schematic', () => {
@@ -16,7 +16,7 @@ describe('Class Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: ClassSchema = {
+  const defaultOptions: ClassOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/component/index_spec.ts
+++ b/packages/schematics/angular/component/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as ComponentSchema } from './schema';
+import { Schema as ComponentOptions } from './schema';
 
 
 describe('Component Schematic', () => {
@@ -17,7 +17,7 @@ describe('Component Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: ComponentSchema = {
+  const defaultOptions: ComponentOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/directive/index_spec.ts
+++ b/packages/schematics/angular/directive/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as DirectiveSchema } from './schema';
+import { Schema as DirectiveOptions } from './schema';
 
 
 describe('Directive Schematic', () => {
@@ -17,7 +17,7 @@ describe('Directive Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: DirectiveSchema = {
+  const defaultOptions: DirectiveOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/enum/index_spec.ts
+++ b/packages/schematics/angular/enum/index_spec.ts
@@ -7,7 +7,7 @@
  */
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
-import { Schema as EnumSchematic } from './schema';
+import { Schema as EnumOptions } from './schema';
 
 
 describe('Enum Schematic', () => {
@@ -15,7 +15,7 @@ describe('Enum Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: EnumSchematic = {
+  const defaultOptions: EnumOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/guard/index_spec.ts
+++ b/packages/schematics/angular/guard/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as GuardSchema } from './schema';
+import { Schema as GuardOptions } from './schema';
 
 
 describe('Guard Schematic', () => {
@@ -17,7 +17,7 @@ describe('Guard Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: GuardSchema = {
+  const defaultOptions: GuardOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/interface/index_spec.ts
+++ b/packages/schematics/angular/interface/index_spec.ts
@@ -8,7 +8,7 @@
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { getFileContent } from '../utility/test';
-import { Schema as InterfaceSchema } from './schema';
+import { Schema as InterfaceOptions } from './schema';
 
 
 describe('Interface Schematic', () => {
@@ -16,7 +16,7 @@ describe('Interface Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: InterfaceSchema = {
+  const defaultOptions: InterfaceOptions = {
     name: 'foo',
     path: 'app',
     prefix: '',

--- a/packages/schematics/angular/module/index_spec.ts
+++ b/packages/schematics/angular/module/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as ModuleSchema } from './schema';
+import { Schema as ModuleOptions } from './schema';
 
 
 describe('Module Schematic', () => {
@@ -17,7 +17,7 @@ describe('Module Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: ModuleSchema = {
+  const defaultOptions: ModuleOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/pipe/index_spec.ts
+++ b/packages/schematics/angular/pipe/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as PipeSchemna } from './schema';
+import { Schema as PipeOptions } from './schema';
 
 
 describe('Pipe Schematic', () => {
@@ -17,7 +17,7 @@ describe('Pipe Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: PipeSchemna = {
+  const defaultOptions: PipeOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -9,7 +9,7 @@ import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/test';
 import * as path from 'path';
 import { createAppModule, getFileContent } from '../utility/test';
-import { Schema as ServiceSchema } from './schema';
+import { Schema as ServiceOptions } from './schema';
 
 
 describe('Pipe Schematic', () => {
@@ -17,7 +17,7 @@ describe('Pipe Schematic', () => {
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
   );
-  const defaultOptions: ServiceSchema = {
+  const defaultOptions: ServiceOptions = {
     name: 'foo',
     path: 'app',
     sourceDir: 'src',


### PR DESCRIPTION
`index.ts` files use `__X__Options` while the `index_spec.ts` files used `__X__Schema`.

Also fixed a typo in the `Service` schematic spec to properly reference it's testing the `Service` schematic.