### PR TITLE
build: add a warning in the package.json of each subpackages

### DIFF
--- a/lib/packages.ts
+++ b/lib/packages.ts
@@ -74,18 +74,24 @@ function loadPackageJson(p: string) {
 
   for (const key of Object.keys(root)) {
     switch (key) {
+      // Keep the following keys from the package.json of the package itself.
       case 'bin':
       case 'description':
       case 'dependencies':
-      case 'devDependencies':
       case 'name':
       case 'main':
       case 'peerDependencies':
-      case 'scripts':
       case 'typings':
       case 'version':
         continue;
 
+      // Remove the following keys from the package.json.
+      case 'devDependencies':
+      case 'scripts':
+        delete pkg[key];
+        continue;
+
+      // Merge the following keys with the root package.json.
       case 'keywords':
         const a = pkg[key] || [];
         const b = Object.keys(
@@ -97,6 +103,7 @@ function loadPackageJson(p: string) {
         pkg[key] = b;
         break;
 
+      // Overwrite the package's key with to root one.
       default:
         pkg[key] = root[key];
     }

--- a/packages/_/benchmark/package.json
+++ b/packages/_/benchmark/package.json
@@ -4,5 +4,8 @@
   "description": "CLI tool for Angular",
   "main": "src/index.js",
   "typings": "src/index.d.ts",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
   "private": true
 }

--- a/packages/angular_devkit/build_optimizer/package.json
+++ b/packages/angular_devkit/build_optimizer/package.json
@@ -8,6 +8,9 @@
     "build-optimizer": "./src/build-optimizer/cli.js",
     "purify": "./src/purify/cli.js"
   },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
   "dependencies": {
     "loader-utils": "^1.1.0",
     "source-map": "^0.5.6",

--- a/packages/angular_devkit/core/package.json
+++ b/packages/angular_devkit/core/package.json
@@ -4,6 +4,9 @@
   "description": "Angular DevKit - Core Utility Library",
   "main": "src/index.js",
   "typings": "src/index.d.ts",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
   "keywords": [
     "core"
   ],

--- a/packages/angular_devkit/schematics/package.json
+++ b/packages/angular_devkit/schematics/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "schematics": "./bin/schematics.js"
   },
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
   "main": "src/index.js",
   "typings": "src/index.d.ts",
   "keywords": [

--- a/packages/schematics/angular/package.json
+++ b/packages/schematics/angular/package.json
@@ -7,6 +7,9 @@
     "code generation",
     "schematics"
   ],
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
   "schematics": "./collection.json",
   "peerDependencies": {
     "@angular-devkit/schematics": "0.0.0"


### PR DESCRIPTION
To avoid people going in those directories and running npm install.

Fixes #172.