### PR TITLE
feat(@angular-devkit/schematics): add support for aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
     "@types/glob": {
       "version": "5.0.32",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.32.tgz",
-      "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
+      "integrity": "sha1-rsXP6YfHLwmf2xGERSmGqlBtXo8=",
       "requires": {
         "@types/minimatch": "3.0.1",
         "@types/node": "6.0.88"
@@ -46,12 +46,12 @@
     "@types/jasmine": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.6.0.tgz",
-      "integrity": "sha512-1ZZdFvYA5zARDXPj5+VF0bwDZWH/o0QQWJVDc5srdC/DngcCZXskR33eR/4PielGvBjLQpQOd6KiQbmtqVkeZA=="
+      "integrity": "sha1-mXtBondStIUK8mg7xKjYIiwlvQI="
     },
     "@types/minimatch": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw=="
+      "integrity": "sha1-toPrYL41gwTvFG9XddtMDjaWpVA="
     },
     "@types/minimist": {
       "version": "1.2.0",
@@ -61,32 +61,32 @@
     "@types/node": {
       "version": "6.0.88",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
-      "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ=="
+      "integrity": "sha1-9hjxGpRPahjZK1xHIChyij49S2Y="
     },
     "@types/semver": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.4.0.tgz",
-      "integrity": "sha512-PBHCvO98hNec9A491vBbh0ZNDOVxccwKL1u2pm6fs9oDgm7SEnw0lEHqHfjsYryDxnE3zaf7LvERWEXjOp1hig=="
+      "integrity": "sha1-82WFNa9/H1AqzW2n2vQF/+sffuQ="
     },
     "@types/source-list-map": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
-      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
+      "integrity": "sha1-AHiDYGP/rxdBI0m7o2QIfgrALsk="
     },
     "@types/source-map": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.1.tgz",
-      "integrity": "sha512-/GVAjL1Y8puvZab63n8tsuBiYwZt1bApMdx58/msQ9ID5T05ov+wm/ZV1DvYC/DKKEygpTJViqQvkh5Rhrl4CA=="
+      "integrity": "sha1-fnTbXQarNzpxI1buv66i+tDqI2c="
     },
     "@types/tapable": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-0.2.4.tgz",
-      "integrity": "sha512-pclMAvhPnXJcJu1ZZ8bQthuUcdDWzDuxDdbSf6l1U6s4fP6EBiZpPsOZYqFOrbqDV97sXGFSsb6AUpiLfv4xIA=="
+      "integrity": "sha1-gYGiKNpGGFQ5MA5gDFrjs7OYJYU="
     },
     "@types/uglify-js": {
       "version": "2.6.29",
       "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-2.6.29.tgz",
-      "integrity": "sha512-BdFLCZW0GTl31AbqXSak8ss/MqEZ3DN2MH9rkAyGoTuzK7ifGUlX+u0nfbWeTsa7IPcZhtn8BlpYBXSV+vqGhQ==",
+      "integrity": "sha1-UhNH9p4gIB0hj1mRrmbhCHivzxo=",
       "requires": {
         "@types/source-map": "0.5.1"
       }
@@ -104,11 +104,20 @@
     "@types/webpack-sources": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.3.tgz",
-      "integrity": "sha512-yS052yVjjyIjwcUqIEe2+JxbWsw27OM8UFb1fLUGacGYtqMRwgAx2qk41VTE/nPMjw/xfD0JiHPD0Q99dlrInA==",
+      "integrity": "sha1-L4uwx6Zs+VLzM8ghdamVWZQyFnQ=",
       "requires": {
         "@types/node": "6.0.88",
         "@types/source-list-map": "0.1.2",
         "@types/source-map": "0.5.1"
+      }
+    },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
       }
     },
     "abbrev": {
@@ -148,7 +157,7 @@
     "ansi-styles": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-      "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+      "integrity": "sha1-wVm41b4PnlpvNG2rlPFs4CIWG4g=",
       "requires": {
         "color-convert": "1.9.0"
       }
@@ -156,7 +165,7 @@
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+      "integrity": "sha1-aALmJk79GMeQobDVF/DyYnvyyUo="
     },
     "are-we-there-yet": {
       "version": "1.1.4",
@@ -296,7 +305,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "integrity": "sha1-pfwpi4G54Nyi5FiCR4S2XFK6WI4="
     },
     "block-stream": {
       "version": "0.0.9",
@@ -368,7 +377,7 @@
     "chalk": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.1.0.tgz",
-      "integrity": "sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==",
+      "integrity": "sha1-rFvs8U+iG5nGySynp9fP1bF+dD4=",
       "requires": {
         "ansi-styles": "3.2.0",
         "escape-string-regexp": "1.0.5",
@@ -383,7 +392,7 @@
         "supports-color": {
           "version": "4.4.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
           "requires": {
             "has-flag": "2.0.0"
           }
@@ -457,7 +466,7 @@
     "commander": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM="
     },
     "compare-func": {
       "version": "1.3.2",
@@ -481,7 +490,7 @@
     "conventional-changelog": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-1.1.5.tgz",
-      "integrity": "sha512-DUM0iXhgE11uRCoEQnFuYQA5zJcxfvKn940ZFyXziFl0y05yBCoy5ci2fcQYFWQ+OyyxgE2H02EdgYpuz9XG4w==",
+      "integrity": "sha1-TEb7ZLKYbKsZiI2MS4fKfA5DG/0=",
       "requires": {
         "conventional-changelog-angular": "1.5.0",
         "conventional-changelog-atom": "0.1.1",
@@ -498,7 +507,7 @@
     "conventional-changelog-angular": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-1.5.0.tgz",
-      "integrity": "sha512-Gt0qSf5wdFmLabgdSlqjguDAmPyYTXtUl4WH5W3SlpElHhnU/UiCY3M7xcIkZxrNQfVA1UxUBgu65eBbaJnZVA==",
+      "integrity": "sha1-ULLUUAhEhFX99n4G6gGXL70IGCo=",
       "requires": {
         "compare-func": "1.3.2",
         "q": "1.5.0"
@@ -507,7 +516,7 @@
     "conventional-changelog-atom": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-0.1.1.tgz",
-      "integrity": "sha512-6Nlu/+MiD4gi7k3Z+N1vMJWpaPSdvFPWzPGnH4OXewHAxiAl0L/TT9CGgA01fosPxmYr4hMNtD7kyN0tkg8vIA==",
+      "integrity": "sha1-1AqbKXlhtTx0Xl0XGP0aM3n2qS8=",
       "requires": {
         "q": "1.5.0"
       }
@@ -515,7 +524,7 @@
     "conventional-changelog-codemirror": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-0.2.0.tgz",
-      "integrity": "sha512-jUbY98JoKdAOR5k3pOBiKZ+Iz9t2F84hL7x4WjSRW6x7FdeCEUOjyfml+YClE2h/h62Tf3mwur5jSO8upxxc1g==",
+      "integrity": "sha1-PMkllV87FEAoJ7FRaASYIZctlFk=",
       "requires": {
         "q": "1.5.0"
       }
@@ -523,7 +532,7 @@
     "conventional-changelog-core": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-1.9.1.tgz",
-      "integrity": "sha512-Fo0bSeO+NsO6GtuQXts0xQeRpLrxaABTPU8NK4Zij9sJB3zFkU4BObSefJS4F4+EkKujaKCWtfS6Uih+9NpXrQ==",
+      "integrity": "sha1-3fdnxAWFDfyN8xcmyA+hpqEL3Hs=",
       "requires": {
         "conventional-changelog-writer": "2.0.1",
         "conventional-commits-parser": "2.0.0",
@@ -543,7 +552,7 @@
     "conventional-changelog-ember": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-0.2.7.tgz",
-      "integrity": "sha512-Xj1v9uVcKM8N798hMr7e6yiw8IFyvI6Ik+TdjdmG54uGupqvEEWW37xAbPPbdKvgoitbyZkqUTancj055actEg==",
+      "integrity": "sha1-xq/zWXYoTnIiZJ+BxivZb/Mhe9I=",
       "requires": {
         "q": "1.5.0"
       }
@@ -551,7 +560,7 @@
     "conventional-changelog-eslint": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-0.2.0.tgz",
-      "integrity": "sha512-WGKnC0bGPD6BHGiRBfYqNGfy6DZDn2jGs1yxPRT8I2796wYdGqsbDF4477o4fdsxUJvckoW2OFPqkmRMQaCHSA==",
+      "integrity": "sha1-tLm13AlBeETYfHvPsWvcxobEscE=",
       "requires": {
         "q": "1.5.0"
       }
@@ -559,7 +568,7 @@
     "conventional-changelog-express": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-0.2.0.tgz",
-      "integrity": "sha512-ujSEmbWfozC1iIjH5Pl7AKtREowvAl10whs1q6c7nZLnoNZK5CmdB2PQ/V42O6rCgUzaLX+ACRW2+g0A/Htqvw==",
+      "integrity": "sha1-jWZq1BsQ6/lkpGAgYt3S4A3rUY0=",
       "requires": {
         "q": "1.5.0"
       }
@@ -583,7 +592,7 @@
     "conventional-changelog-jshint": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-0.2.0.tgz",
-      "integrity": "sha512-uUP4c0et6F2teapl+YY2JHFAHD401U5CkgI+P8PyU0y1zS8BdBy6EnhqgZEXhFOp9fPzUdic+Wv/9alOqw3agQ==",
+      "integrity": "sha1-Y6167GbNGuVZuv6ANIxGV6brGHI=",
       "requires": {
         "compare-func": "1.3.2",
         "q": "1.5.0"
@@ -592,7 +601,7 @@
     "conventional-changelog-writer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-2.0.1.tgz",
-      "integrity": "sha512-X4qC758celQOKw0iUPAsH5sJX6fH6N5dboFc3elXb1/SIKhsYMukhhaxWmxRdtVUSqGt9rZg8giwBQG5B2GeKg==",
+      "integrity": "sha1-R8END6ulJreNGUOJ0ekx0J7mI3I=",
       "requires": {
         "compare-func": "1.3.2",
         "conventional-commits-filter": "1.0.0",
@@ -618,10 +627,10 @@
     "conventional-commits-parser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-2.0.0.tgz",
-      "integrity": "sha512-8od6g684Fhi5Vpp4ABRv/RBsW1AY6wSHbJHEK6FGTv+8jvAAnlABniZu/FVmX9TcirkHepaEsa1QGkRvbg0CKw==",
+      "integrity": "sha1-cdAZEMsKma6yDBROUPgfTfMXhEc=",
       "requires": {
-        "is-text-path": "1.0.1",
         "JSONStream": "1.3.1",
+        "is-text-path": "1.0.1",
         "lodash": "4.17.4",
         "meow": "3.7.0",
         "split2": "2.1.1",
@@ -695,7 +704,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -737,7 +746,7 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "integrity": "sha1-qoVnpu7QPFMfyJ0/cRzQ5SWd7HU="
     },
     "dot-prop": {
       "version": "3.0.0",
@@ -777,7 +786,7 @@
     "es-abstract": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.8.2.tgz",
-      "integrity": "sha512-dvhwFL3yjQxNNsOWx6exMlaDrRHCRGMQlnx5lsXDCZ/J7G/frgIIl94zhZSp/galVAYp7VzPi1OrAHta89/yGQ==",
+      "integrity": "sha1-JRAyY9xN7L2mDgxzfKMjE1GAJ+4=",
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -946,7 +955,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "gauge": {
       "version": "2.7.4",
@@ -1019,7 +1028,7 @@
     "git-semver-tags": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-1.2.1.tgz",
-      "integrity": "sha512-fFyxtzTHCTQKwB4clA2AInVrlflBbVbbJD4NWwmxKXHUgsU/K9kmHNlkPLqFiuy9xu9q3lNopghR4VXeQwZbTQ==",
+      "integrity": "sha1-bM0qUuc1tzZ0jcdiRE/NlYjidJA=",
       "requires": {
         "meow": "3.7.0",
         "semver": "5.4.1"
@@ -1036,7 +1045,7 @@
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
       "requires": {
         "fs.realpath": "1.0.0",
         "inflight": "1.0.6",
@@ -1131,7 +1140,7 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "integrity": "sha1-bWDjSzq7yDEwYsO3mO+NkBoHrzw="
     },
     "http-signature": {
       "version": "1.1.1",
@@ -1341,7 +1350,7 @@
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -1350,7 +1359,7 @@
         "esprima": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
         }
       }
     },
@@ -1392,15 +1401,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
       "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -1514,7 +1514,7 @@
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-      "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "integrity": "sha1-Yi4y6CSItJJ5EUpPns9F581rulU=",
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -1599,7 +1599,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -1612,7 +1612,7 @@
     "minipass": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.1.tgz",
-      "integrity": "sha512-u1aUllxPJUI07cOqzR7reGmQxmCqlH88uIIsf6XZFEWgw7gXKpJdR+5R9Y3KEDmWYkdIz9wXZs3C0jOPxejk/Q==",
+      "integrity": "sha1-WtqXU4sQJ7TPchNDJChXjLVkAR8=",
       "requires": {
         "yallist": "3.0.2"
       },
@@ -1691,7 +1691,7 @@
         "rimraf": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "requires": {
             "glob": "7.1.2"
           }
@@ -1719,7 +1719,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -1730,8 +1730,9 @@
     "npm": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/npm/-/npm-5.4.2.tgz",
-      "integrity": "sha512-F6LLCAHriKyKQ9Ff03UKCjkXZoRBp281I42K42+VeHfjAXZ3TJdg3RccinzoCFV1kDxCedVm7AstIpb1Uf5UkQ==",
+      "integrity": "sha1-gwtcq7X3NSZOfMObIWO5CFSy6qg=",
       "requires": {
+        "JSONStream": "1.3.1",
         "abbrev": "1.1.0",
         "ansi-regex": "3.0.0",
         "ansicolors": "0.3.2",
@@ -1761,7 +1762,6 @@
         "inherits": "2.0.3",
         "ini": "1.3.4",
         "init-package-json": "1.10.1",
-        "JSONStream": "1.3.1",
         "lazy-property": "1.0.0",
         "libnpx": "9.6.0",
         "lockfile": "1.0.3",
@@ -1832,6 +1832,24 @@
         "write-file-atomic": "2.1.0"
       },
       "dependencies": {
+        "JSONStream": {
+          "version": "1.3.1",
+          "bundled": true,
+          "requires": {
+            "jsonparse": "1.3.1",
+            "through": "2.3.8"
+          },
+          "dependencies": {
+            "jsonparse": {
+              "version": "1.3.1",
+              "bundled": true
+            },
+            "through": {
+              "version": "2.3.8",
+              "bundled": true
+            }
+          }
+        },
         "abbrev": {
           "version": "1.1.0",
           "bundled": true
@@ -2128,24 +2146,6 @@
               "requires": {
                 "read": "1.0.7"
               }
-            }
-          }
-        },
-        "JSONStream": {
-          "version": "1.3.1",
-          "bundled": true,
-          "requires": {
-            "jsonparse": "1.3.1",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "through": {
-              "version": "2.3.8",
-              "bundled": true
             }
           }
         },
@@ -4700,7 +4700,7 @@
     "npm-run-all": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.1.tgz",
-      "integrity": "sha512-qrmqqaJa+REbzUTIL/mHfTdgwz+gL1xUezY/ueyLa7GISZ4T3h0CH8D2r6AaZdCYN2unu7PzspP0ofpXla1ftg==",
+      "integrity": "sha1-MJXPPzys9X/LZishCrEMYJr23bs=",
       "requires": {
         "ansi-styles": "3.2.0",
         "chalk": "2.1.0",
@@ -4762,7 +4762,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "requires": {
         "are-we-there-yet": "1.1.4",
         "console-control-strings": "1.1.0",
@@ -5034,7 +5034,7 @@
     "readable-stream": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-      "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -5117,7 +5117,7 @@
     "rxjs": {
       "version": "5.4.3",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.3.tgz",
-      "integrity": "sha512-fSNi+y+P9ss+EZuV0GcIIqPUK07DEaMRUtLJvdcvMyFjc9dizuDjere+A4V7JrLGnm9iCc+nagV/4QdMTkqC4A==",
+      "integrity": "sha1-B1jN3uYDPWjg/VNnbw81ls49SD8=",
       "requires": {
         "symbol-observable": "1.0.4"
       }
@@ -5125,12 +5125,12 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
     },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
     },
     "serializerr": {
       "version": "1.0.3",
@@ -5185,7 +5185,7 @@
     "source-list-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.0.tgz",
-      "integrity": "sha512-I2UmuJSRr/T8jisiROLU3A3ltr+swpniSmNPI4Ml3ZCX6tVnDsuZzK7F2hl5jTqbZBWCEKlj5HRQiPExXLgE8A=="
+      "integrity": "sha1-qqR0A/eyRakvvJfqCPJQ1gh+0IU="
     },
     "source-map": {
       "version": "0.5.7",
@@ -5195,7 +5195,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -5221,7 +5221,7 @@
     "split": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
       "requires": {
         "through": "2.3.8"
       }
@@ -5269,14 +5269,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -5295,6 +5287,14 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.8.2",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -5352,7 +5352,7 @@
     "tar": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/tar/-/tar-3.2.1.tgz",
-      "integrity": "sha512-ZSzds1E0IqutvMU8HxjMaU8eB7urw2fGwTq88ukDOVuUIh0656l7/P7LiVPxhO5kS4flcRJQk8USG+cghQbTUQ==",
+      "integrity": "sha1-mqjkHIjwnnbBZgdbxx+T1RZuYbE=",
       "requires": {
         "chownr": "1.0.1",
         "minipass": "2.2.1",
@@ -5386,7 +5386,7 @@
         "rimraf": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "integrity": "sha1-LtgVDSShbqhlHm1u8PR8QVjOejY=",
           "requires": {
             "glob": "7.1.2"
           }
@@ -5415,7 +5415,7 @@
     "text-extensions": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.6.0.tgz",
-      "integrity": "sha512-U2M04F2rbuYYCNioiTD14cImLTae4ys1rC57tllzKg3dt5DPR2JXs5yFdC017yOBrW6wM6s5gtAlFJ7yye04rA=="
+      "integrity": "sha1-dxVhsmAieDpF9bbC54rW596f4yI="
     },
     "through": {
       "version": "2.3.8",
@@ -5545,7 +5545,7 @@
         "resolve": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+          "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
           "requires": {
             "path-parse": "1.0.5"
           }
@@ -5622,7 +5622,7 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
     },
     "v8-profiler": {
       "version": "5.7.0",
@@ -5670,7 +5670,7 @@
     "webpack-sources": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.0.1.tgz",
-      "integrity": "sha512-05tMxipUCwHqYaVS8xc7sYPTly8PzXayRCB4dTxLhWTqlKUiwH6ezmEe0OSreL1c30LAuA3Zqmc+uEBUGFJDjw==",
+      "integrity": "sha1-xzVkNqTRMSO+LiQmoF0drZy+Zc8=",
       "requires": {
         "source-list-map": "2.0.0",
         "source-map": "0.5.7"
@@ -5679,7 +5679,7 @@
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
       "requires": {
         "isexe": "2.0.0"
       }
@@ -5687,7 +5687,7 @@
     "wide-align": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
+      "integrity": "sha1-Vx4PGwYEY268DfwhsDObvjE0FxA=",
       "requires": {
         "string-width": "1.0.2"
       }

--- a/packages/angular_devkit/core/src/json/schema/schema.ts
+++ b/packages/angular_devkit/core/src/json/schema/schema.ts
@@ -5,10 +5,10 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { JsonArray, JsonValue } from '../interface';
+import { JsonArray, JsonObject, JsonValue } from '../interface';
 
 
-export interface JsonSchemaBase {
+export interface JsonSchemaBase extends Partial<JsonObject> {
   $schema?: string;
   $id?: string;
 
@@ -20,12 +20,12 @@ export interface JsonSchemaBase {
 
   // Reference properties.
   $ref?: string;
-  allOf?: JsonSchema[];
-  anyOf?: JsonSchema[];
-  oneOf?: JsonSchema[];
+  allOf?: (JsonObject & JsonSchema)[];
+  anyOf?: (JsonObject & JsonSchema)[];
+  oneOf?: (JsonObject & JsonSchema)[];
 
   // Structural properties.
-  definitions?: { [name: string]: JsonSchema };
+  definitions?: { [name: string]: (JsonObject & JsonSchema) };
 }
 
 export interface JsonSchemaString {
@@ -66,29 +66,29 @@ export interface JsonSchemaObject extends JsonSchemaBase {
   type: 'object';
 
   // Object properties.
-  properties?: { [name: string]: JsonSchema };
-  patternProperties?: { [pattern: string]: JsonSchema };
+  properties?: { [name: string]: (JsonObject & JsonSchema) };
+  patternProperties?: { [pattern: string]: (JsonObject & JsonSchema) };
   required?: string[];
   minProperties?: number;
   maxProperties?: number;
 
-  dependencies?: { [name: string]: JsonSchema | string[]; };
+  dependencies?: { [name: string]: (string & JsonSchema) | string[]; };
 
-  additionalProperties?: boolean | JsonSchema;
+  additionalProperties?: boolean | (JsonObject & JsonSchema);
 }
 
 export interface JsonSchemaArray extends JsonSchemaBase {
   type: 'array';
 
-  additionalItems?: boolean | JsonSchema;
-  items?: JsonSchema | JsonSchema[];
+  additionalItems?: boolean | (JsonObject & JsonSchema);
+  items?: JsonArray;
   maxItems?: number;
   minItems?: number;
   uniqueItems?: boolean;
 }
 
 export interface JsonSchemaOneOfType extends JsonSchemaBase {
-  type: JsonSchemaBaseType[];
+  type: JsonArray & (JsonSchemaBaseType[]);
 }
 
 export interface JsonSchemaAny {

--- a/packages/angular_devkit/schematics/tools/description.ts
+++ b/packages/angular_devkit/schematics/tools/description.ts
@@ -5,6 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import { JsonObject } from '@angular-devkit/core';
 import {
   Collection,
   CollectionDescription,
@@ -22,6 +23,7 @@ export interface FileSystemCollectionDescription {
 
 
 export interface FileSystemSchematicJsonDescription {
+  readonly aliases?: string[];
   readonly factory: string;
   readonly description: string;
   readonly schema?: string;
@@ -31,7 +33,7 @@ export interface FileSystemSchematicJsonDescription {
 export interface FileSystemSchematicDescription extends FileSystemSchematicJsonDescription {
   // Processed by the EngineHost.
   readonly path: string;
-  readonly schemaJson?: Object;
+  readonly schemaJson?: JsonObject;
   // Using `any` here is okay because the type isn't resolved when we read this value,
   // but rather when the Engine asks for it.
   readonly factoryFn: RuleFactory<{}>;

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:no-any
+import { SchematicEngine } from '@angular-devkit/schematics';
+import { FileSystemEngineHost } from '@angular-devkit/schematics/tools';
+import * as path from 'path';
+
+describe('FileSystemEngineHost', () => {
+  const devkitRoot = (global as any)._DevKitRoot;
+  const root = path.join(
+    devkitRoot,
+    'tests/@angular_devkit/schematics/tools/file-system-engine-host',
+  );
+
+  it('works', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('works');
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1.description.name).toBe('schematic1');
+  });
+
+  it('understands aliases', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('aliases');
+    const schematic1 = engine.createSchematic('alias1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+  });
+
+  it('errors on invalid aliases', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => engine.createCollection('invalid-aliases')).toThrow();
+  });
+
+  it('errors on invalid aliases (2)', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => engine.createCollection('invalid-aliases-2')).toThrow();
+  });
+});

--- a/packages/angular_devkit/schematics/tools/index.ts
+++ b/packages/angular_devkit/schematics/tools/index.ts
@@ -10,6 +10,6 @@ export * from './file-system-host';
 export * from './file-system-engine-host-base';
 
 export { FallbackEngineHost } from './fallback-engine-host';
-export {FileSystemEngineHost} from './file-system-engine-host';
-export {NodeModulesEngineHost} from './node-module-engine-host';
+export { FileSystemEngineHost } from './file-system-engine-host';
+export { NodeModulesEngineHost } from './node-module-engine-host';
 export { NodeModulesTestEngineHost } from './node-modules-test-engine-host';

--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -6,76 +6,58 @@
       "description": "Create an Angular application."
     },
     "class": {
+      "aliases": [ "cl" ],
       "factory": "./class",
       "description": "Create a class.",
       "schema": "./class/schema.json"
     },
-    "cl": {
-      "extends": "class"
-    },
     "component": {
+      "aliases": [ "c" ],
       "factory": "./component",
       "description": "Create an Angular component.",
       "schema": "./component/schema.json"
     },
-    "c": {
-      "extends": "component"
-    },
     "directive": {
+      "aliases": [ "d" ],
       "factory": "./directive",
       "description": "Create an Angular directive.",
       "schema": "./directive/schema.json"
     },
-    "d": {
-      "extends": "directive"
-    },
     "enum": {
+      "aliases": [ "e" ],
       "factory": "./enum",
       "description": "Create an enumeration.",
       "schema": "./enum/schema.json"
     },
-    "e": {
-      "extends": "enum"
-    },
     "guard": {
+      "aliases": [ "g" ],
       "factory": "./guard",
       "description": "Create a guard.",
       "schema": "./guard/schema.json"
     },
-    "g": {
-      "extends": "guard"
-    },
     "interface": {
+      "aliases": [ "i" ],
       "factory": "./interface",
       "description": "Create an interface.",
       "schema": "./interface/schema.json"
     },
-    "i": {
-      "extends": "interface"
-    },
     "module": {
+      "aliases": [ "m" ],
       "factory": "./module",
       "description": "Create an Angular module.",
       "schema": "./module/schema.json"
     },
-    "m": {
-      "extends": "module"
-    },
     "pipe": {
+      "aliases": [ "p" ],
       "factory": "./pipe",
       "description": "Create an Angular pipe.",
       "schema": "./pipe/schema.json"
     },
-    "p": {
-      "extends": "pipe"
-    },
     "service": {
+      "aliases": [ "s" ],
       "factory": "./service",
       "description": "Create an Angular service.",
       "schema": "./service/schema.json"
-    },
-    "s": {
-      "extends": "service"
     }
   }
 }

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/aliases/collection.json
@@ -1,0 +1,14 @@
+{
+  "name": "aliases",
+  "schematics": {
+    "schematic1": {
+      "aliases": ["alias1"],
+      "description": "1",
+      "factory": "../null-factory"
+    },
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/invalid-aliases-2/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/invalid-aliases-2/collection.json
@@ -1,0 +1,15 @@
+{
+  "name": "invalid-aliases-2",
+  "schematics": {
+    "schematic1": {
+      "aliases": ["alias1"],
+      "description": "1",
+      "factory": "../null-factory"
+    },
+    "schematic2": {
+      "aliases": ["alias1"],
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/invalid-aliases/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/invalid-aliases/collection.json
@@ -1,0 +1,14 @@
+{
+  "name": "invalid-aliases",
+  "schematics": {
+    "schematic1": {
+      "aliases": ["schematic2"],
+      "description": "1",
+      "factory": "../null-factory"
+    },
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/null-factory.ts
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/null-factory.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export default function() {
+  return () => {};
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/works/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/works/collection.json
@@ -1,0 +1,9 @@
+{
+  "name": "works",
+  "schematics": {
+    "schematic1": {
+      "description": "1",
+      "factory": "../null-factory"
+    }
+  }
+}


### PR DESCRIPTION
Aliases are supported in the FileSystemEngineHostBase (and derivatives). When a
schematic is resolved the name being resolved will be replaced if a schematic
of the collection has an alias that matches the name.

Having 2 aliases be the same on two different schematics, or having an alias
be the same name as a schematic are both an error.

Also added much needed tests for file-system-engine-host.