### PR TITLE
feat(@schematics/angular): save ng new options as defaults

### DIFF
--- a/packages/schematics/angular/application/files/__dot__angular-cli.json
+++ b/packages/schematics/angular/application/files/__dot__angular-cli.json
@@ -54,13 +54,14 @@
     }
   },
   "defaults": {
-    "styleExt": "<%= style %>",<% if (!minimal) { %>
-    "component": {}<% } else { %>
-    "component": {
-      "spec": false,
-      "inlineStyle": true,
+    "styleExt": "<%= style %>",
+    "component": {<% if (minimal || inlineStyle) { %>
+      "inlineStyle": true
+    <% } %><% if (minimal || (inlineTemplate && inlineStyle)) { %>,<% } %><% if (minimal || inlineTemplate) { %>
       "inlineTemplate": true
-    },
+    <% } %><% if (minimal || (skipTests && (inlineStyle || inlineTemplate))) { %>,<% } %><% if (minimal || skipTests) { %>
+      "spec": false
+    <% } %>}<% if (minimal || skipTests) { %>,
     "directive": {
       "spec": false
     },
@@ -78,6 +79,6 @@
     },
     "service": {
       "spec": false
-    } <% } %>
+    }<% } %>
   }
 }


### PR DESCRIPTION
If a create an app with the CLI with the `--inline-template` option, I don't just want the `AppComponent` with inline template, I surely want inline templates everywhere.

Same goes for `--inline-style` and `--skip-tests`.

So this PR save the options used during `ng new`, which are related to future generate commands, as defaults in `.angular-cli.json`.

This is particularly helpful for beginners : skipping tests (= less files to mess with) and inlining templates (easier to see relations between class and view) is better to learn at first, but having to reconfigure the `.angular-cli.json` after the `ng new` is cumbersome, especially when people don't understand yet at this time what they are configuring.

I just need confirmation that `||` and `&&` operators work here, but I suppose the tests will answer this question.

Fixes angular/angular-cli#8004