### PR TITLE
refactor: move all CLI-specific exceptions to different options

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -73,6 +73,10 @@ function minimalPathFilter(path: string): boolean {
   return !toRemoveList.some(re => re.test(path));
 }
 export default function (options: ApplicationOptions): Rule {
+  if (!options.name) {
+    options.name = options._[0];
+  }
+
   return (host: Tree, context: SchematicContext) => {
     const appRootSelector = `${options.prefix}-root`;
     const componentOptions = !options.minimal ?

--- a/packages/schematics/angular/application/schema.d.ts
+++ b/packages/schematics/angular/application/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     /**
      * The directory name to create the app in.
      */

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Application Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "directory": {
       "type": "string",
       "description": "The directory name to create the app in.",

--- a/packages/schematics/angular/class/index.ts
+++ b/packages/schematics/angular/class/index.ts
@@ -20,10 +20,13 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { Schema as ClassOptions } from './schema';
 
 
 export default function (options: ClassOptions): Rule {
+  parseOptions('class', options);
+
   options.type = !!options.type ? `.${options.type}` : '';
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;

--- a/packages/schematics/angular/class/schema.d.ts
+++ b/packages/schematics/angular/class/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     appRoot?: string;
     path?: string;

--- a/packages/schematics/angular/class/schema.json
+++ b/packages/schematics/angular/class/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Class Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/component/index.ts
+++ b/packages/schematics/angular/component/index.ts
@@ -24,6 +24,7 @@ import {
 import 'rxjs/add/operator/merge';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
@@ -102,6 +103,8 @@ function buildSelector(options: ComponentOptions) {
 
 
 export default function(options: ComponentOptions): Rule {
+  parseOptions('component', options);
+
   const sourceDir = options.sourceDir;
   if (!sourceDir) {
     throw new SchematicsException(`sourceDir option is required.`);

--- a/packages/schematics/angular/component/schema.d.ts
+++ b/packages/schematics/angular/component/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     path?: string;
     appRoot?: string;
     sourceDir?: string;

--- a/packages/schematics/angular/component/schema.json
+++ b/packages/schematics/angular/component/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Application Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "path": {
       "type": "string",
       "default": "app"

--- a/packages/schematics/angular/directive/index.ts
+++ b/packages/schematics/angular/directive/index.ts
@@ -24,6 +24,7 @@ import {
 import 'rxjs/add/operator/merge';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
@@ -99,6 +100,8 @@ function buildSelector(options: DirectiveOptions) {
 }
 
 export default function (options: DirectiveOptions): Rule {
+  parseOptions('directive', options);
+
   options.selector = options.selector || buildSelector(options);
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;

--- a/packages/schematics/angular/directive/schema.d.ts
+++ b/packages/schematics/angular/directive/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/directive/schema.json
+++ b/packages/schematics/angular/directive/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Class Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/enum/index.ts
+++ b/packages/schematics/angular/enum/index.ts
@@ -18,10 +18,13 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { Schema as EnumOptions } from './schema';
 
 
 export default function (options: EnumOptions): Rule {
+  parseOptions('enum', options);
+
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
   if (!sourceDir) {

--- a/packages/schematics/angular/enum/schema.d.ts
+++ b/packages/schematics/angular/enum/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/enum/schema.json
+++ b/packages/schematics/angular/enum/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Enum Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/guard/index.ts
+++ b/packages/schematics/angular/guard/index.ts
@@ -24,6 +24,7 @@ import {
 import 'rxjs/add/operator/merge';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addProviderToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
@@ -66,6 +67,8 @@ function addDeclarationToNgModule(options: GuardOptions): Rule {
 }
 
 export default function (options: GuardOptions): Rule {
+  parseOptions('guard', options);
+
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
   if (!sourceDir) {

--- a/packages/schematics/angular/guard/schema.d.ts
+++ b/packages/schematics/angular/guard/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     spec?: boolean;
     flat?: boolean;

--- a/packages/schematics/angular/guard/schema.json
+++ b/packages/schematics/angular/guard/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Guard Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/interface/index.ts
+++ b/packages/schematics/angular/interface/index.ts
@@ -18,10 +18,13 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { Schema as InterfaceOptions } from './schema';
 
 
 export default function (options: InterfaceOptions): Rule {
+  parseOptions('interface', options);
+
   options.prefix = options.prefix ? options.prefix : '';
   options.type = !!options.type ? `.${options.type}` : '';
   options.path = options.path ? normalize(options.path) : options.path;

--- a/packages/schematics/angular/interface/schema.d.ts
+++ b/packages/schematics/angular/interface/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/interface/schema.json
+++ b/packages/schematics/angular/interface/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Interface Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -23,6 +23,7 @@ import {
 } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addImportToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { findModuleFromOptions } from '../utility/find-module';
@@ -70,6 +71,8 @@ function addDeclarationToNgModule(options: ModuleOptions): Rule {
 }
 
 export default function (options: ModuleOptions): Rule {
+  parseOptions('module', options);
+
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
   if (!sourceDir) {

--- a/packages/schematics/angular/module/schema.d.ts
+++ b/packages/schematics/angular/module/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/module/schema.json
+++ b/packages/schematics/angular/module/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Module Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/pipe/index.ts
+++ b/packages/schematics/angular/pipe/index.ts
@@ -24,6 +24,7 @@ import {
 import 'rxjs/add/operator/merge';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addDeclarationToModule, addExportToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
@@ -86,6 +87,8 @@ function addDeclarationToNgModule(options: PipeOptions): Rule {
 }
 
 export default function (options: PipeOptions): Rule {
+  parseOptions('pipe', options);
+
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
   if (!sourceDir) {

--- a/packages/schematics/angular/pipe/schema.d.ts
+++ b/packages/schematics/angular/pipe/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/pipe/schema.json
+++ b/packages/schematics/angular/pipe/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Pipe Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -24,6 +24,7 @@ import {
 import 'rxjs/add/operator/merge';
 import * as ts from 'typescript';
 import * as stringUtils from '../strings';
+import { parseOptions } from '../utility/args';
 import { addProviderToModule } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
@@ -70,6 +71,8 @@ function addProviderToNgModule(options: ServiceOptions): Rule {
 }
 
 export default function (options: ServiceOptions): Rule {
+  parseOptions('service', options);
+
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
   if (!sourceDir) {

--- a/packages/schematics/angular/service/schema.d.ts
+++ b/packages/schematics/angular/service/schema.d.ts
@@ -7,6 +7,15 @@
  */
 
 export interface Schema {
+    // tslint:disable-next-line:no-any
+    _?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliAppConfig?: any;
+    // tslint:disable-next-line:no-any
+    _angularCliParsedPath?: any;
+
     name: string;
     path?: string;
     appRoot?: string;

--- a/packages/schematics/angular/service/schema.json
+++ b/packages/schematics/angular/service/schema.json
@@ -4,6 +4,11 @@
   "title": "Angular Service Options Schema",
   "type": "object",
   "properties": {
+    "_": {},
+    "_angularCliConfig": {},
+    "_angularCliAppConfig": {},
+    "_angularCliParsedPath": {},
+
     "name": {
       "type": "string"
     },

--- a/packages/schematics/angular/utility/args.ts
+++ b/packages/schematics/angular/utility/args.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { dasherize } from '../strings';
+
+
+// tslint:disable-next-line:no-any
+export function parseOptions(schematicName: string, commandOptions: any) {
+  const {
+    _,
+    _angularCliConfig: cliConfig,
+    _angularCliAppConfig: appConfig,
+    _angularCliParsedPath: parsedPath,
+  } = commandOptions;
+
+  // If name is passed in, just ignore it. It's either backward compatible or being called by
+  // another schematic.
+  if (commandOptions.name) {
+    return;
+  }
+
+  commandOptions.name = dasherize(_[0].split(/[\\/]/g).pop());
+  commandOptions.sourceDir = appConfig.root;
+
+  const root = appConfig.root + '/';
+  commandOptions.appRoot = parsedPath.appRoot === appConfig.root ? '' :
+    parsedPath.appRoot.startsWith(root)
+      ? parsedPath.appRoot.substr(root.length)
+      : parsedPath.appRoot;
+
+  commandOptions.path = parsedPath.dir;
+  commandOptions.path = parsedPath.dir === appConfig.root ? '' :
+    parsedPath.dir.startsWith(root)
+      ? commandOptions.path.substr(root.length)
+      : commandOptions.path;
+  if (['component', 'directive'].indexOf(schematicName) !== -1) {
+    const root = commandOptions.$$originalRoot ? commandOptions.$$originalRoot() : commandOptions;
+    if (root.prefix === undefined) {
+      commandOptions.prefix = appConfig.prefix;
+    }
+
+    if (schematicName === 'component') {
+      if (root.styleext === undefined) {
+        commandOptions.styleext = cliConfig.defaults && cliConfig.defaults.styleExt;
+      }
+    }
+  }
+
+  if (schematicName === 'interface' && _[1]) {
+    commandOptions.type = _[1];
+  }
+}


### PR DESCRIPTION
This is supposed to be released at the same time as https://github.com/angular/angular-cli/pull/7981, but is backward compatible.