### PR TITLE
fix(@angular-devkit/build-optimizer): don't add imports to files with…

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib.ts
@@ -11,7 +11,13 @@ import * as ts from 'typescript';
 export function testImportTslib(content: string) {
   const regex = /var (__extends|__decorate|__metadata|__param) = \(.*\r?\n(    .*\r?\n)*\};/;
 
-  return regex.test(content);
+  // This transform introduces import/require() calls, but this won't work properly on libraries
+  // built with Webpack. These libraries use __webpack_require__() calls instead, which will break
+  // with a new import that wasn't part of it's original module list.
+  // We ignore this transform for such libraries.
+  const webpackRequireRegex = /__webpack_require__/;
+
+  return regex.test(content) && !webpackRequireRegex.test(content);
 }
 
 export function getImportTslibTransformer(): ts.TransformerFactory<ts.SourceFile> {

--- a/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/import-tslib_spec.ts
@@ -96,4 +96,19 @@ describe('import-tslib', () => {
 
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
+
+  it('tests false for files using __webpack_require__', () => {
+    const input = tags.stripIndent`
+      function __webpack_require__(moduleId) {
+          var __extends = (this && this.__extends) || function (d, b) {
+              for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+              function __() { this.constructor = d; }
+              d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+          };
+          exports.meaning = 42;
+      }
+    `;
+
+    expect(testImportTslib(input)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
… custom webpack require

Libraries using the custom `__webpack_require__` won't correctly load new imports.

Partially address https://github.com/angular/angular-cli/issues/6196.