### PR TITLE
fix(@schematics/angular): remove the Reflect polyfill

### DIFF
--- a/packages/schematics/angular/application/files/__path__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__path__/polyfills.ts
@@ -37,8 +37,12 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
+/** IE10 and IE11 requires the following for the Reflect API. */
+// import 'core-js/es6/reflect';
+
+
 /** Evergreen browsers require these. **/
-import 'core-js/es6/reflect';
+// Used for reflect-metadata in JIT. If you use AOT (and only Angular decorators), you can remove.
 import 'core-js/es7/reflect';
 
 


### PR DESCRIPTION
Only IE11 and less needs it. See http://kangax.github.io/compat-table/es6/#test-Reflect

Fixes #206.