### PR TITLE
fix(@schematics/angular): Sort defaults alphabetically

### DIFF
--- a/packages/schematics/angular/application/files/__dot__angular-cli.json
+++ b/packages/schematics/angular/application/files/__dot__angular-cli.json
@@ -55,6 +55,9 @@
   },
   "defaults": {
     "styleExt": "<%= style %>",
+    "class": {
+      "spec": false
+    },
     "component": {<% if (minimal || inlineStyle) { %>
       "inlineStyle": true
     <% } %><% if (minimal || (inlineTemplate && inlineStyle)) { %>,<% } %><% if (minimal || inlineTemplate) { %>
@@ -63,9 +66,6 @@
       "spec": false
     <% } %>}<% if (minimal || skipTests) { %>,
     "directive": {
-      "spec": false
-    },
-    "class": {
       "spec": false
     },
     "guard": {


### PR DESCRIPTION
The current order is not sorted alphabetically. so `.angular-cli.json` will make diff after `ng set` command. 