### PR TITLE
fix(@schematics/angular): Turn on strict mode by default in tsconfig

### DIFF
--- a/packages/schematics/angular/application/files/tsconfig.json
+++ b/packages/schematics/angular/application/files/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist/out-tsc",
     "sourceMap": true,
+    "strict": true,
     "declaration": false,
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
This should have been turned on to set the best practice from the beginning for the CLI generated project.