### PR TITLE
fix(@schematics/angular): missing condition and comma position

### DIFF
--- a/packages/schematics/angular/application/files/__dot__angular-cli.json
+++ b/packages/schematics/angular/application/files/__dot__angular-cli.json
@@ -54,15 +54,13 @@
     }
   },
   "defaults": {
-    "styleExt": "<%= style %>",
+    "styleExt": "<%= style %>",<% if (minimal || skipTests) { %>
     "class": {
       "spec": false
-    },
+    },<% } %>
     "component": {<% if (minimal || inlineStyle) { %>
-      "inlineStyle": true
-    <% } %><% if (minimal || (inlineTemplate && inlineStyle)) { %>,<% } %><% if (minimal || inlineTemplate) { %>
-      "inlineTemplate": true
-    <% } %><% if (minimal || (skipTests && (inlineStyle || inlineTemplate))) { %>,<% } %><% if (minimal || skipTests) { %>
+      "inlineStyle": true<% } %><% if (minimal || (inlineTemplate && inlineStyle)) { %>,<% } %><% if (minimal || inlineTemplate) { %>
+      "inlineTemplate": true<% } %><% if (minimal || (skipTests && (inlineStyle || inlineTemplate))) { %>,<% } %><% if (minimal || skipTests) { %>
       "spec": false
     <% } %>}<% if (minimal || skipTests) { %>,
     "directive": {


### PR DESCRIPTION
Fixes PR #213 which sorted the options without taking the conditions into consideration, resulting in `class: { spec: false }` for everyone.

Fixes PR #196 comma position.