### PR TITLE
fix(@schematics/angular): build in --prod mode by default

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
According to the idea the CLI should be ready to use, if I want to work in dev, I run `npm start`, and if I want to go in production, I run `npm run build`. But currently the build is in dev mode by default, requiring the user to know he/she has to go to modify the npm script accordingly.

@hansl @filipesilva 