### PR TITLE
feat(@schematics/angular): service worker project generation

### DIFF
--- a/packages/schematics/angular/application/files/__path__/ngsw-config.json
+++ b/packages/schematics/angular/application/files/__path__/ngsw-config.json
@@ -1,0 +1,27 @@
+{
+  "index": "/index.html",
+  "assetGroups": [{
+    "name": "app",
+    "installMode": "prefetch",
+    "resources": {
+      "files": [
+        "/favicon.ico",
+        "/index.html"
+      ],
+      "versionedFiles": [
+        "/*.bundle.css",
+        "/*.bundle.js",
+        "/*.chunk.js"
+      ]
+    }
+  }, {
+    "name": "assets",
+    "installMode": "lazy",
+    "updateMode": "prefetch",
+    "resources": {
+      "files": [
+        "/assets/**"
+      ]
+    }
+  }]
+}

--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -20,7 +20,8 @@
     "@angular/http": "^5.0.0",
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
-    "@angular/router": "^5.0.0",
+    "@angular/router": "^5.0.0",<% if (serviceWorker) { %>
+    "@angular/service-worker": "^5.0.0",<% } %>
     "core-js": "^2.4.1",
     "rxjs": "^5.5.2",
     "zone.js": "^0.8.14"

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -95,6 +95,7 @@ export default function (options: ApplicationOptions): Rule {
         apply(url('./files'), [
           options.minimal ? filter(minimalPathFilter) : noop(),
           options.skipGit ? filter(path => !path.endsWith('/__dot__gitignore')) : noop(),
+          options.serviceWorker ? noop() : filter(path => !path.endsWith('/ngsw-config.json')),
           template({
             utils: stringUtils,
             'dot': '.',

--- a/packages/schematics/angular/application/other-files/app.module.ts
+++ b/packages/schematics/angular/application/other-files/app.module.ts
@@ -2,7 +2,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 <% if (routing) { %>
 import { AppRoutingModule } from './app-routing.module';<% } %>
+<% if (serviceWorker) { %>
+import { ServiceWorkerModule } from '@angular/service-worker';<% } %>
 import { AppComponent } from './app.component';
+<% if (serviceWorker) { %>
+import { environment } from '../environments/environment';<% } %>
 
 @NgModule({
   declarations: [
@@ -10,7 +14,8 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule<% if (routing) { %>,
-    AppRoutingModule<% } %>
+    AppRoutingModule<% } %><% if (serviceWorker) { %>,
+    environment.production ? ServiceWorkerModule.register('/ngsw-worker.js') : []<% } %>
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/packages/schematics/angular/application/schema.d.ts
+++ b/packages/schematics/angular/application/schema.d.ts
@@ -52,4 +52,8 @@ export interface Schema {
      * Should create a minimal app.
      */
     minimal?: boolean;
+    /**
+     * Should install the @angular/service-worker.
+     */
+    serviceWorker?: boolean;
 }

--- a/packages/schematics/angular/application/schema.json
+++ b/packages/schematics/angular/application/schema.json
@@ -79,6 +79,11 @@
       "description": "Should create a minimal app.",
       "type": "boolean",
       "default": false
+    },
+    "serviceWorker": {
+      "description": "Should install the @angular/service-worker.",
+      "type": "boolean",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
This adds a feature to the Angular application schematic to generate a
project which includes @angular/service-worker's ServiceWorkerModule,
conditionally enabled for production builds. An ngsw.json file with
configuration suited for most projects is also generated.

Both operations are gated on the --service-worker flag which is added.