### PR TITLE
feat(typescript): allow downlevelIteration in Angular 5

### DIFF
--- a/packages/schematics/angular/application/files/tsconfig.json
+++ b/packages/schematics/angular/application/files/tsconfig.json
@@ -14,6 +14,7 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ],
+    "downlevelIteration": true
   }
 }


### PR DESCRIPTION
Before TypeScript 2.3, when targeting ES5 (which is the case in Angular CLI), `for ... of` was limited to `Array`. Meaning it's not possible to iterate easily on new iterables like `Map`.

It's now possible since TypeScript 2.3, but requires the flag `downlevelIteration`. As Angular 5 requires TS >= 2.4, it's OK to enable this flag by default.

@hansl @filipesilva @Brocco I don't know how to manage the option to be Angular >= 5 (or TypeScript >= 2.3) only in schematics. Is there a variable available for that, or is there another system to separate between Angular versions (as I suppose similar cases will happen) ?