### PR TITLE
fix(@schematics/schematics): use the version of schematics that is in…

### DIFF
--- a/packages/schematics/schematics/schematic/factory.ts
+++ b/packages/schematics/schematics/schematic/factory.ts
@@ -19,11 +19,16 @@ import { Schema } from './schema';
 
 
 export default function (options: Schema): Rule {
+  const schematicsVersion = require('@angular-devkit/schematics/package.json').version;
+  const coreVersion = require('@angular-devkit/core/package.json').version;
+
   return mergeWith(apply(url('./files'), [
     partitionApplyMerge(
       (p: Path) => !/\/src\/.*?\/files\//.test(p),
       template({
         ...options as object,
+        coreVersion,
+        schematicsVersion,
         dot: '.',
         dasherize,
       }),

--- a/packages/schematics/schematics/schematic/files/package.json
+++ b/packages/schematics/schematics/schematic/files/package.json
@@ -13,8 +13,8 @@
   "license": "MIT",
   "schematics": "./src/collection.json",
   "dependencies": {
-    "@angular-devkit/core": "^0.0.15",
-    "@angular-devkit/schematics": "^0.0.25",
+    "@angular-devkit/core": "^<%= coreVersion %>",
+    "@angular-devkit/schematics": "^<%= schematicsVersion %>",
     "@types/jasmine": "^2.6.0",
     "@types/node": "^8.0.31",
     "jasmine": "^2.8.0",


### PR DESCRIPTION
…stalled

Take the version of the global package when creating a new schematic.