### PR TITLE
fix(@angular-devkit/build-optimizer): use the real sourcemaps

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
@@ -53,8 +53,10 @@ export default function buildOptimizerLoader
       // source map chaining example.
       // Use http://sokra.github.io/source-map-visualization/ to validate sourcemaps make sense.
 
-      // Fill in the intermediate sourcemap source as the previous sourcemap file.
-      intermediateSourceMap.sources = [previousSourceMap.file];
+      // Fill in the intermediate sourcemap sources as the previous sourcemap sources.
+      if (previousSourceMap.sources) {
+        intermediateSourceMap.sources = previousSourceMap.sources;
+      }
 
       // Chain the sourcemaps.
       const consumer = new SourceMapConsumer(intermediateSourceMap);


### PR DESCRIPTION
Some sourcemaps do not have file attribute (which points to the file the sourcemap is
relating to anyway, not the source sourcemap). Those files used to map to "undefined",
not anymore.