### PR TITLE
docs(@schematics/angular): adjust statement of Zone.js prolyfill

### DIFF
--- a/packages/schematics/angular/application/files/__path__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__path__/polyfills.ts
@@ -55,7 +55,7 @@ import 'core-js/es7/reflect';
 
 
 /***************************************************************************************************
- * Zone JS is required by Angular itself.
+ * Zone JS is required by default for Angular itself.
  */
 import 'zone.js/dist/zone';  // Included with Angular CLI.
 


### PR DESCRIPTION
With https://github.com/angular/angular/commit/344a5ca5452bc01a1e5ff8f04aa7a283ce4134cf landed at `5.0.0-rc.0`, Zone.js is no longer a requirement of Angular when using `NoopNgZone`.

<sub>~~There is currently a bug https://github.com/angular/angular/issues/19534 for misusing Zone.js in Angular, so it would give a false alert when not using Zone.js for now.~~ fixed already</sub>

Relates to https://github.com/angular/angular/pull/20121, the requirement statement has been fixed already in Angular itself. Likely the message should be consistent?