### PR TITLE
feat: update codelyzer and add rules

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -32,7 +32,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
-    "codelyzer": "~3.2.0",
+    "codelyzer": "^4.0.1",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",

--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -127,6 +127,8 @@
       "<%= prefix %>",
       "kebab-case"
     ],
+    "angular-whitespace": [true, "check-interpolation"],
+    "no-output-on-prefix": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,
     "use-host-property-decorator": true,
@@ -135,7 +137,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
codelyzer@^4.0.0 is out 🎉! It introduces support for `@angular/compiler` version 5 and few new rules such as:

- `angular-whitespace` - checks whether we have presence of whitespace
in the template to make it more readable, for instance
in `{{ expr }}`, `check-interpolation` will check if `expr` is
surrounded by whitespace. This rule also introduces auto fixes.
- `no-output-on-prefix` - warns if outputs are prefixed with `on` this
is based on
https://angular.io/guide/styleguide#dont-prefix-output-properties.

Tell me what you think about `angular-whitespace` and let me know if it
is too opinionated. As part of `angular-whitespace` we're planning a few
more features.

Also, since `invoke-injectable` is supposed to be caught by `tsc`, this rule has been deprecated.

Fixes angular/angular-cli#8463