### PR TITLE
feat(@schematics/angular): remove deprecated http package

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -17,7 +17,6 @@
     "@angular/compiler": "^5.0.0",
     "@angular/core": "^5.0.0",
     "@angular/forms": "^5.0.0",
-    "@angular/http": "^5.0.0",
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",


### PR DESCRIPTION
Now that `@angular/http` is officially deprecated, we can probably remove it from the default package.json.