### PR TITLE
refactor(@angular-devkit/schematics): make filesystem tree get/read/branch lazy

### DIFF
--- a/packages/angular_devkit/schematics/src/tree/memory-host.ts
+++ b/packages/angular_devkit/schematics/src/tree/memory-host.ts
@@ -42,6 +42,11 @@ export class InMemoryFileSystemTreeHost implements FileSystemTreeHost {
 
     return this._content[path] || new Buffer('');
   }
+  exists(path: string) {
+    path = normalize(path);
+
+    return this._content[path] != undefined;
+  }
 
   join(path1: string, path2: string) {
     return normalize(path1 + '/' + path2);

--- a/packages/angular_devkit/schematics/src/tree/node-host.ts
+++ b/packages/angular_devkit/schematics/src/tree/node-host.ts
@@ -22,6 +22,9 @@ export class NodeJsHost implements FileSystemTreeHost {
   readFile(path: string) {
     return fs.readFileSync(this.join(this._root, path));
   }
+  exists(path: string) {
+    return fs.existsSync(this.join(this._root, path));
+  }
 
   join(path1: string, path2: string) {
     return join(path1, path2);

--- a/packages/angular_devkit/schematics/tools/file-system-host.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-host.ts
@@ -7,7 +7,7 @@
  */
 import { fs } from '@angular-devkit/core/node';
 import { FileSystemTreeHost } from '@angular-devkit/schematics';
-import { readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 export class FileSystemHost implements FileSystemTreeHost {
@@ -21,6 +21,9 @@ export class FileSystemHost implements FileSystemTreeHost {
   }
   readFile(path: string) {
     return readFileSync(join(this._root, path));
+  }
+  exists(path: string) {
+    return existsSync(this.join(this._root, path));
   }
 
   join(path1: string, path2: string) {


### PR DESCRIPTION
This prevents the get, read, and branch calls of the filesystem tree from causing a full walk of the underlying file system host.