### PR TITLE
feat(@angular-devkit/build-optimizer): make decorator removal configurable

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -14,7 +14,7 @@ describe('build-optimizer', () => {
   const imports = 'import { Injectable, Input, Component } from \'@angular/core\';';
   const clazz = 'var Clazz = (function () { function Clazz() { } return Clazz; }());';
   const staticProperty = 'Clazz.prop = 1;';
-  const decorators = 'Clazz.decorators = [ { type: Injectable } ];';
+  const decorators = 'Clazz.decorators = [{ type: Injectable }];';
 
   describe('basic functionality', () => {
     it('applies class-fold, scrub-file and prefix-functions to side-effect free modules', () => {
@@ -98,6 +98,22 @@ describe('build-optimizer', () => {
       const boOutput = buildOptimizer({ content: input });
       expect(boOutput.content).toBeFalsy();
       expect(boOutput.emitSkipped).toEqual(true);
+    });
+
+    it('doesn\'t remove decorators if option is disabled', () => {
+      const input = tags.oneLine`
+        import { Injectable } from '@angular/core';
+        ${clazz}
+        ${decorators}
+      `;
+      const output = tags.oneLine`
+        import { Injectable } from '@angular/core';
+        var Clazz = (function () { function Clazz() { } ${decorators} return Clazz; }());
+      `;
+
+      const boOutput = buildOptimizer({ content: input, removeDecorators: false });
+      expect(tags.oneLine`${boOutput.content}`).toEqual(output);
+      expect(boOutput.emitSkipped).toEqual(false);
     });
 
     it('supports es2015 modules', () => {

--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/webpack-loader.ts
@@ -14,6 +14,7 @@ import { buildOptimizer } from './build-optimizer';
 
 interface BuildOptimizerLoaderOptions {
   sourceMap: boolean;
+  removeDecorators?: boolean;
 }
 
 export default function buildOptimizerLoader
@@ -28,6 +29,7 @@ export default function buildOptimizerLoader
     // Without a name the sourcemaps cannot be properly chained.
     outputFilePath: this.resourcePath + '.build-optimizer.js',
     emitSourceMap: options.sourceMap,
+    removeDecorators: options.removeDecorators,
   });
 
   if (boOutput.emitSkipped || boOutput.content === null) {


### PR DESCRIPTION
The option defaults to true; maintaining existing behavior.