### PR TITLE
fix(@schematics/angular): ignore system files in service worker

### DIFF
--- a/packages/schematics/angular/application/files/__path__/ngsw-config.json
+++ b/packages/schematics/angular/application/files/__path__/ngsw-config.json
@@ -20,7 +20,9 @@
     "updateMode": "prefetch",
     "resources": {
       "files": [
-        "/assets/**"
+        "/assets/**",
+        "!/assets/**/.DS_Store",
+        "!/assets/**/Thumbs.db"
       ]
     }
   }]


### PR DESCRIPTION
Fixes angular/mobile-toolkit#180

When copying the assets, the CLI includes system files (e.g. .DS_Store and Thumbs.db). As a consequence, they are included in the service worker manifest as files to cache. But such file may (and should) not be deployed to the server, then a file will be missing, then the service worker installation will fail and so all the offline feature won't work.

This PR ensure the service worker will ignore these system files.

@hansl @filipesilva 