### PR TITLE
fix(@schematics/angular): include fonts in service worker

### DIFF
--- a/packages/schematics/angular/application/files/__path__/ngsw-config.json
+++ b/packages/schematics/angular/application/files/__path__/ngsw-config.json
@@ -11,7 +11,8 @@
       "versionedFiles": [
         "/*.bundle.css",
         "/*.bundle.js",
-        "/*.chunk.js"
+        "/*.chunk.js",
+        "/*.woff2"
       ]
     }
   }, {


### PR DESCRIPTION
Angular CLI does a great job including fonts from CSS in the build step (very useful in Material for example). The service worker should include them, otherwise the service worker will fail and the app won't work offline (when some ressources are missing, a service worker cancels installation).

I'm only including WOFF2 format, as all browsers supporting service workers also support WOFF2.

@hansl @filipesilva 