### PR TITLE
fix(@schematics/angular): set tslint to emit warnings

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -2,6 +2,7 @@
   "rulesDirectory": [
     "node_modules/codelyzer"
   ],
+  "defaultSeverity": "warn",
   "rules": {
     "arrow-return-shorthand": true,
     "callable-types": true,


### PR DESCRIPTION
tslint 5 is now raising errors by default, instead of warnings previously, and it's very confusing (lint errors can't be displayed the same way as real syntax errors).

@hansl @Brocco @filipesilva 