### PR TITLE
fix(@schematics/angular): Upgrade codelyzer (for ng5) to 4.0.0

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -33,7 +33,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
-    "codelyzer": "~3.2.0",
+    "codelyzer": "^4.0.0",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",


### PR DESCRIPTION
For ng5, codelyzer to be upgraded to ^4.0.0. 

More details at - https://github.com/mgechev/codelyzer/blob/master/CHANGELOG.md#400 .

See Issue Number: angular/angular-cli#8463. 

After this, later to be manually synced: angular/angular#20392