### PR TITLE
feat(@schematics/angular): add manifest for service-worker

### DIFF
--- a/packages/schematics/angular/application/files/__dot__angular-cli.json
+++ b/packages/schematics/angular/application/files/__dot__angular-cli.json
@@ -9,7 +9,8 @@
       "outDir": "dist",
       "assets": [
         "assets",
-        "favicon.ico"
+        "favicon.ico"<% if (serviceWorker) { %>,
+        "manifest.json"<% } %>
       ],
       "index": "index.html",
       "main": "main.ts",

--- a/packages/schematics/angular/application/files/__path__/manifest.json
+++ b/packages/schematics/angular/application/files/__path__/manifest.json
@@ -1,0 +1,9 @@
+{
+  "short_name": "<%= prefix %>",
+  "name": "<%= prefix %>",
+  "icons": [],
+  "start_url": "/index.html",
+  "display": "standalone",
+  "background_color": "",
+  "theme_color": ""
+}

--- a/packages/schematics/angular/application/files/__sourcedir__/index.html
+++ b/packages/schematics/angular/application/files/__sourcedir__/index.html
@@ -6,7 +6,8 @@
   <base href="/">
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <link rel="icon" type="image/x-icon" href="favicon.ico"><% if (serviceWorker) { %>
+  <link rel="manifest" href="manifest.json"><% } %>
 </head>
 <body>
   <<%= prefix %>-root></<%= prefix %>-root>

--- a/packages/schematics/angular/application/files/__sourcedir__/ngsw-config.json
+++ b/packages/schematics/angular/application/files/__sourcedir__/ngsw-config.json
@@ -6,7 +6,8 @@
     "resources": {
       "files": [
         "/favicon.ico",
-        "/index.html"
+        "/index.html",
+        "/manifest.json"
       ],
       "versionedFiles": [
         "/*.bundle.css",

--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -95,7 +95,8 @@ export default function (options: ApplicationOptions): Rule {
         apply(url('./files'), [
           options.minimal ? filter(minimalPathFilter) : noop(),
           options.skipGit ? filter(path => !path.endsWith('/__dot__gitignore')) : noop(),
-          options.serviceWorker ? noop() : filter(path => !path.endsWith('/ngsw-config.json')),
+          options.serviceWorker ? noop() : filter(path => !path.endsWith('/ngsw-config.json')
+                                                          && !path.endsWith('/manifest.json')),
           template({
             utils: stringUtils,
             ...options as object,


### PR DESCRIPTION
An app manifest is required to pass the Lighthouse PWA audit.

@hansl @filipesilva @Brocco 