### PR TITLE
fix(@schematics/angular): remove Intl polyfill

### DIFF
--- a/packages/schematics/angular/application/files/__path__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__path__/polyfills.ts
@@ -64,13 +64,3 @@ import 'zone.js/dist/zone';  // Included with Angular CLI.
 /***************************************************************************************************
  * APPLICATION IMPORTS
  */
-
-/**
- * Date, currency, decimal and percent pipes.
- * Needed for: All but Chrome, Firefox, Edge, IE11 and Safari 10
- */
-// import 'intl';  // Run `npm install --save intl`.
-/**
- * Need to import at least one locale-data with intl.
- */
-// import 'intl/locale-data/jsonp/en';


### PR DESCRIPTION
As the i18n pipes have been rewritten in Angular 5, we shouldn't need the Intl polyfill now.