### PR TITLE
fix(@angular-devkit/build-optimizer): allow optimization of IIFE bundles

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
@@ -31,6 +31,57 @@ describe('scrub-file', () => {
       expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
     });
 
+
+    it('removes Angular decorators calls in __decorate with top-level IIFE', () => {
+      const output = tags.stripIndent`
+        import { Component } from '@angular/core';
+        (function () {
+          var Clazz = (function () {
+            function Clazz() { }
+            return Clazz;
+          })();
+        })();
+        (function () {
+          var Clazz = (function () {
+            function Clazz() { }
+            return Clazz;
+          })();
+        }());
+      `;
+      const input = tags.stripIndent`
+        import { Component } from '@angular/core';
+        (function () {
+          var Clazz = (function () {
+            function Clazz() { }
+            Clazz = __decorate([
+              Component({
+                selector: 'app-root',
+                templateUrl: './app.component.html',
+                styleUrls: ['./app.component.css']
+              })
+            ], Clazz);
+            return Clazz;
+          })();
+        })();
+        (function () {
+          var Clazz = (function () {
+            function Clazz() { }
+            Clazz = __decorate([
+              Component({
+                selector: 'app-root',
+                templateUrl: './app.component.html',
+                styleUrls: ['./app.component.css']
+              })
+            ], Clazz);
+            return Clazz;
+          })();
+        }());
+      `;
+
+      expect(testScrubFile(input)).toBeTruthy();
+      expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+    });
+
     it('removes nested Angular decorators', () => {
       const output = tags.stripIndent`
         import { Injectable } from '@angular/core';


### PR DESCRIPTION
Rollup produces a bundle where it wraps everything into an IIFE. Because
of the `checkNodeForDecorators` check the scrub transformer was
returning before entering the IIFE and respectively wasn't dropping
Angular-specific decorators.

The current check enters the transform if the top-level node is not an
`ExpressionStatement` or is an `ExpressionStatement` and IIFE.