### PR TITLE
refactor(@schematics/angular): Removing Whitespace from Angular default schematics

### DIFF
--- a/packages/schematics/angular/class/files/__path__/__name@dasherize____type__.ts
+++ b/packages/schematics/angular/class/files/__path__/__name@dasherize____type__.ts
@@ -1,2 +1,1 @@
-export class <%= classify(name) %> {
-}
+export class <%= classify(name) %> { }

--- a/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -15,6 +15,5 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
 })
 export class <%= classify(name) %>Component implements OnInit {
   constructor() { }
-
   ngOnInit() { }
 }

--- a/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -15,5 +15,6 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
 })
 export class <%= classify(name) %>Component implements OnInit {
   constructor() { }
+
   ngOnInit() { }
 }

--- a/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
+++ b/packages/schematics/angular/component/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.component.ts
@@ -14,10 +14,7 @@ import { Component, OnInit<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
 export class <%= classify(name) %>Component implements OnInit {
-
   constructor() { }
 
-  ngOnInit() {
-  }
-
+  ngOnInit() { }
 }

--- a/packages/schematics/angular/directive/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.directive.ts
+++ b/packages/schematics/angular/directive/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.directive.ts
@@ -4,7 +4,5 @@ import { Directive } from '@angular/core';
   selector: '[<%= selector %>]'
 })
 export class <%= classify(name) %>Directive {
-
   constructor() { }
-
 }

--- a/packages/schematics/angular/enum/files/__path__/__name@dasherize__.enum.ts
+++ b/packages/schematics/angular/enum/files/__path__/__name@dasherize__.enum.ts
@@ -1,2 +1,1 @@
-export enum <%= classify(name) %> {
-}
+export enum <%= classify(name) %> { }

--- a/packages/schematics/angular/interface/files/__path__/__name@dasherize____type__.ts
+++ b/packages/schematics/angular/interface/files/__path__/__name@dasherize____type__.ts
@@ -1,2 +1,1 @@
-export interface <%= prefix %><%= classify(name) %> {
-}
+export interface <%= prefix %><%= classify(name) %> { }

--- a/packages/schematics/angular/pipe/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts
+++ b/packages/schematics/angular/pipe/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.pipe.ts
@@ -1,12 +1,8 @@
 import { Pipe, PipeTransform } from '@angular/core';
 
-@Pipe({
-  name: '<%= camelize(name) %>'
-})
+@Pipe({ name: '<%= camelize(name) %>' })
 export class <%= classify(name) %>Pipe implements PipeTransform {
-
   transform(value: any, args?: any): any {
     return null;
   }
-
 }

--- a/packages/schematics/angular/service/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.service.ts
+++ b/packages/schematics/angular/service/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.service.ts
@@ -2,7 +2,5 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class <%= classify(name) %>Service {
-
   constructor() { }
-
 }


### PR DESCRIPTION
**What** 
I reduced the whitespace in the schematics. 

**Why**
When teaching Angular, folks have often really liked when the code is tighter for the newly generated files.  This also matches the snippets I have referenced in the style guide.


