### PR TITLE
feat(@schematics/angular): update codelyzer

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -33,7 +33,7 @@
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
-    "codelyzer": "~3.2.0",
+    "codelyzer": "~4.0.0",
     "jasmine-core": "~2.6.2",
     "jasmine-spec-reporter": "~4.1.0",
     "karma": "~1.7.0",

--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -135,7 +135,6 @@
     "use-life-cycle-interface": true,
     "use-pipe-transform-interface": true,
     "component-class-suffix": true,
-    "directive-class-suffix": true,
-    "invoke-injectable": true
+    "directive-class-suffix": true
   }
 }


### PR DESCRIPTION
Codelyzer 4 is required for Angular 5 and a rule is now deprecated.

Fixes angular/angular-cli#8324
Fixes angular/angular-cli#8463