### PR TITLE
fix(@schematics/angular): revert breaking angular-whitespace lint rule

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -127,7 +127,6 @@
       "<%= prefix %>",
       "kebab-case"
     ],
-    "angular-whitespace": [true, "check-interpolation"],
     "no-output-on-prefix": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,


### PR DESCRIPTION
While updating to Codelyzer 4.0, #257 also added a new `angular-whitespace` rule.

This must be reverted because :
- it is a breaking change : existing project are now failing on lint ;
- it is opinionated (it is not in official Angular style guide) and so should not be forced ;
- it is the contrary of what is done in the official Angular doc and in the style guide itself.

@hansl @filipesilva @Brocco @mgechev 