### PR TITLE
feat(@schematics/angular): add deprecation rule

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -11,6 +11,9 @@
       "check-space"
     ],
     "curly": true,
+    "deprecation": {
+      "severity": "warn"
+    },
     "eofline": true,
     "forin": true,
     "import-blacklist": [


### PR DESCRIPTION
Angular uses the ` @deprecated` tag when a function is deprecated. Since Angular's roadmap is intensive, it could be fine to have a warn as soon as possible when we use have a deprecated functionnality in our code.

Tslint can help us !