### PR TITLE
fix(@schematics/angular): enable prod mode for universal

### DIFF
--- a/packages/schematics/angular/universal/files/__sourceDir__/__main@stripTsExtension__.ts
+++ b/packages/schematics/angular/universal/files/__sourceDir__/__main@stripTsExtension__.ts
@@ -1,1 +1,9 @@
+import { enableProdMode } from '@angular/core';
+
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
 export { <%= rootModuleClassName %> } from './<%= appDir %>/<%= stripTsExtension(rootModuleFileName) %>';


### PR DESCRIPTION
Universal build should be in production mode for performance.

It also avoid an issue with Material which produces an error (`window is not defined`) in development mode.

@filipesilva @hansl @Brocco 