### PR TITLE
fix(@schematics/angular): don't overwrite target for specs

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/tsconfig.spec.json
+++ b/packages/schematics/angular/application/files/__sourcedir__/tsconfig.spec.json
@@ -4,7 +4,6 @@
     "outDir": "<%= sourcedir.split('/').map(x => '..').join('/') %>/out-tsc/spec",
     "baseUrl": "./",
     "module": "commonjs",
-    "target": "es5",
     "types": [
       "jasmine",
       "node"


### PR DESCRIPTION
There's no need to.