### PR TITLE
feat(@angular/schematics): use TS 2.5

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -45,6 +45,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.7.0",<% } %>
-    "typescript": "~2.4.2"
+    "typescript": "~2.5.3"
   }
 }


### PR DESCRIPTION
As Angular 5.1 now supports TS 2.5, this should now be the default TS version.