### PR TITLE
refactor(@schematics/angular): Import dasherize from core

### DIFF
--- a/packages/schematics/angular/utility/find-module.ts
+++ b/packages/schematics/angular/utility/find-module.ts
@@ -5,9 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { Path, join, normalize, relative } from '@angular-devkit/core';
+import { Path, join, normalize, relative, dasherize } from '@angular-devkit/core';
 import { DirEntry, Tree } from '@angular-devkit/schematics';
-import { dasherize } from '../strings';
 
 
 export interface ModuleOptions {


### PR DESCRIPTION
Seems like this `dasherize` is the same function exported on `@angular-devkit/core/src/utils/strings.ts`: https://github.com/angular/devkit/blob/master/packages/angular_devkit/core/src/utils/strings.ts#L46