### PR TITLE
refactor(@angular-devkit/build-optimizer): improve resiliency of enum wrapper

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -58,12 +58,11 @@ describe('build-optimizer', () => {
         /** PURE_IMPORTS_START _angular_core,tslib PURE_IMPORTS_END */
         ${imports}
         import { __extends } from "tslib";
-        var ChangeDetectionStrategy = /*@__PURE__*/ (function () {
-          var ChangeDetectionStrategy = {};
+        var ChangeDetectionStrategy = /*@__PURE__*/ (function (ChangeDetectionStrategy) {
           ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
           ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
           return ChangeDetectionStrategy;
-        })();
+        })({});
         var Clazz = /*@__PURE__*/ (function () { function Clazz() { } ${staticProperty} return Clazz; }());
         var ComponentClazz = /*@__PURE__*/ (function () {
           function ComponentClazz() { }

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -35,7 +35,7 @@ export function getWrapEnumsTransformer(): ts.TransformerFactory<ts.SourceFile> 
 
       const result = visitBlockStatements(sf.statements, context);
 
-      return ts.updateSourceFileNode(sf, result);
+      return ts.updateSourceFileNode(sf, ts.setTextRange(result, sf.statements));
     };
 
     return transformer;
@@ -52,10 +52,11 @@ function visitBlockStatements(
 
   const visitor: ts.Visitor = (node) => {
     if (isBlockLike(node)) {
-      const result = visitBlockStatements(node.statements, context);
+      let result = visitBlockStatements(node.statements, context);
       if (result === node.statements) {
         return node;
       }
+      result = ts.setTextRange(result, node.statements);
       switch (node.kind) {
         case ts.SyntaxKind.Block:
           return ts.updateBlock(node as ts.Block, result);
@@ -98,18 +99,16 @@ function visitBlockStatements(
         const name = variableDeclaration.name.text;
 
         if (!variableDeclaration.initializer) {
-          const enumStatements = findTs2_3EnumStatements(name, statements[oIndex + 1]);
-          if (enumStatements.length > 0) {
+          const iife = findTs2_3EnumIife(name, statements[oIndex + 1]);
+          if (iife) {
             // found an enum
             if (!updatedStatements) {
               updatedStatements = statements.slice();
             }
-            // create wrapper and replace variable statement and IIFE
-            updatedStatements.splice(uIndex, 2, createWrappedEnum(
-              name,
+            // update IIFE and replace variable statement and old IIFE
+            updatedStatements.splice(uIndex, 2, updateEnumIife(
               currentStatement,
-              enumStatements,
-              undefined,
+              iife,
             ));
             // skip IIFE statement
             oIndex++;
@@ -117,8 +116,7 @@ function visitBlockStatements(
           }
         } else if (ts.isObjectLiteralExpression(variableDeclaration.initializer)
                    && variableDeclaration.initializer.properties.length === 0) {
-          const nextStatements = statements.slice(oIndex + 1);
-          const enumStatements = findTs2_2EnumStatements(name, nextStatements);
+          const enumStatements = findTs2_2EnumStatements(name, statements, oIndex + 1);
           if (enumStatements.length > 0) {
             // found an enum
             if (!updatedStatements) {
@@ -138,8 +136,7 @@ function visitBlockStatements(
         } else if (ts.isObjectLiteralExpression(variableDeclaration.initializer)
           && variableDeclaration.initializer.properties.length !== 0) {
           const literalPropertyCount = variableDeclaration.initializer.properties.length;
-          const nextStatements = statements.slice(oIndex + 1);
-          const enumStatements = findTsickleEnumStatements(name, nextStatements);
+          const enumStatements = findTsickleEnumStatements(name, statements, oIndex + 1);
           if (enumStatements.length === literalPropertyCount) {
             // found an enum
             if (!updatedStatements) {
@@ -175,9 +172,10 @@ function visitBlockStatements(
 }
 
 // TS 2.3 enums have statements that are inside a IIFE.
-function findTs2_3EnumStatements(name: string, statement: ts.Statement): ts.ExpressionStatement[] {
-  const enumStatements: ts.ExpressionStatement[] = [];
-  const noNodes: ts.ExpressionStatement[] = [];
+function findTs2_3EnumIife(name: string, statement: ts.Statement): ts.CallExpression | null {
+  if (!ts.isExpressionStatement(statement) || !ts.isCallExpression(statement.expression)) {
+    return null;
+  }
 
   const funcExpr = drilldownNodes<ts.FunctionExpression>(statement,
     [
@@ -187,14 +185,14 @@ function findTs2_3EnumStatements(name: string, statement: ts.Statement): ts.Expr
       { prop: 'expression', kind: ts.SyntaxKind.FunctionExpression },
     ]);
 
-  if (funcExpr === null) { return noNodes; }
+  if (funcExpr === null) { return null; }
 
   if (!(
     funcExpr.parameters.length === 1
     && funcExpr.parameters[0].name.kind === ts.SyntaxKind.Identifier
     && (funcExpr.parameters[0].name as ts.Identifier).text === name
   )) {
-    return noNodes;
+    return null;
   }
 
   // In TS 2.3 enums, the IIFE contains only expressions with a certain format.
@@ -207,13 +205,11 @@ function findTs2_3EnumStatements(name: string, statement: ts.Statement): ts.Expr
         { prop: 'expression', kind: ts.SyntaxKind.BinaryExpression },
       ]);
 
-    if (innerBinExpr === null) { return noNodes; }
-
-    const exprStmt = innerStmt as ts.ExpressionStatement;
+    if (innerBinExpr === null) { return null; }
 
     if (!(innerBinExpr.operatorToken.kind === ts.SyntaxKind.FirstAssignment
         && innerBinExpr.left.kind === ts.SyntaxKind.ElementAccessExpression)) {
-      return noNodes;
+      return null;
     }
 
     const innerElemAcc = innerBinExpr.left as ts.ElementAccessExpression;
@@ -224,13 +220,13 @@ function findTs2_3EnumStatements(name: string, statement: ts.Statement): ts.Expr
       && innerElemAcc.argumentExpression
       && innerElemAcc.argumentExpression.kind === ts.SyntaxKind.BinaryExpression
     )) {
-      return noNodes;
+      return null;
     }
 
     const innerArgBinExpr = innerElemAcc.argumentExpression as ts.BinaryExpression;
 
     if (innerArgBinExpr.left.kind !== ts.SyntaxKind.ElementAccessExpression) {
-      return noNodes;
+      return null;
     }
 
     const innerArgElemAcc = innerArgBinExpr.left as ts.ElementAccessExpression;
@@ -239,28 +235,27 @@ function findTs2_3EnumStatements(name: string, statement: ts.Statement): ts.Expr
       innerArgElemAcc.expression.kind === ts.SyntaxKind.Identifier
       && (innerArgElemAcc.expression as ts.Identifier).text === name
     )) {
-      return noNodes;
+      return null;
     }
-
-    enumStatements.push(exprStmt);
   }
 
-  return enumStatements;
+  return statement.expression;
 }
 
 // TS 2.2 enums have statements after the variable declaration, with index statements followed
 // by value statements.
 function findTs2_2EnumStatements(
   name: string,
-  statements: ts.Statement[],
+  statements: ts.NodeArray<ts.Statement>,
+  statementOffset: number,
 ): ts.ExpressionStatement[] {
   const enumStatements: ts.ExpressionStatement[] = [];
   let beforeValueStatements = true;
 
-  for (const stmt of statements) {
+  for (let index = statementOffset; index < statements.length; index++) {
     // Ensure all statements are of the expected format and using the right identifer.
     // When we find a statement that isn't part of the enum, return what we collected so far.
-    const binExpr = drilldownNodes<ts.BinaryExpression>(stmt,
+    const binExpr = drilldownNodes<ts.BinaryExpression>(statements[index],
       [
         { prop: null, kind: ts.SyntaxKind.ExpressionStatement },
         { prop: 'expression', kind: ts.SyntaxKind.BinaryExpression },
@@ -273,7 +268,7 @@ function findTs2_2EnumStatements(
       return beforeValueStatements ? [] : enumStatements;
     }
 
-    const exprStmt = stmt as ts.ExpressionStatement;
+    const exprStmt = statements[index] as ts.ExpressionStatement;
     const leftExpr = binExpr.left as ts.PropertyAccessExpression | ts.ElementAccessExpression;
 
     if (!(leftExpr.expression.kind === ts.SyntaxKind.Identifier
@@ -298,75 +293,46 @@ function findTs2_2EnumStatements(
 // See https://github.com/angular/devkit/issues/229#issuecomment-338512056 fore more information.
 function findTsickleEnumStatements(
   name: string,
-  statements: ts.Statement[],
-): ts.ExpressionStatement[] {
-  const enumStatements: ts.ExpressionStatement[] = [];
-  // let beforeValueStatements = true;
+  statements: ts.NodeArray<ts.Statement>,
+  statementOffset: number,
+): ts.Statement[] {
+  const enumStatements: ts.Statement[] = [];
 
-  for (const stmt of statements) {
+  for (let index = statementOffset; index < statements.length; index++) {
     // Ensure all statements are of the expected format and using the right identifer.
     // When we find a statement that isn't part of the enum, return what we collected so far.
-    const binExpr = drilldownNodes<ts.BinaryExpression>(stmt,
+    const access = drilldownNodes<ts.ElementAccessExpression>(statements[index],
       [
         { prop: null, kind: ts.SyntaxKind.ExpressionStatement },
         { prop: 'expression', kind: ts.SyntaxKind.BinaryExpression },
+        { prop: 'left', kind: ts.SyntaxKind.ElementAccessExpression },
       ]);
 
-    if (binExpr === null || binExpr.left.kind !== ts.SyntaxKind.ElementAccessExpression) {
-      return enumStatements;
+    if (!access) {
+      break;
     }
 
-    const exprStmt = stmt as ts.ExpressionStatement;
-    const leftExpr = binExpr.left as ts.ElementAccessExpression;
-
-    if (!(leftExpr.expression.kind === ts.SyntaxKind.Identifier
-        && (leftExpr.expression as ts.Identifier).text === name)) {
-      return enumStatements;
+    if (!ts.isIdentifier(access.expression) || access.expression.text !== name) {
+      break;
     }
-    enumStatements.push(exprStmt);
+
+    if (!access.argumentExpression || !ts.isPropertyAccessExpression(access.argumentExpression)) {
+      break;
+    }
+
+    const enumExpression = access.argumentExpression.expression;
+    if (!ts.isIdentifier(enumExpression) || enumExpression.text !== name) {
+      break;
+    }
+
+    enumStatements.push(statements[index]);
   }
 
   return enumStatements;
 }
 
-function createWrappedEnum(
-  name: string,
-  hostNode: ts.VariableStatement,
-  statements: Array<ts.Statement>,
-  literalInitializer: ts.ObjectLiteralExpression | undefined,
-): ts.Statement {
+function updateHostNode(hostNode: ts.VariableStatement, expression: ts.Expression): ts.Statement {
   const pureFunctionComment = '@__PURE__';
-
-  literalInitializer = literalInitializer || ts.createObjectLiteral();
-  const innerVarStmt = ts.createVariableStatement(
-    undefined,
-    ts.createVariableDeclarationList([
-      ts.createVariableDeclaration(name, undefined, literalInitializer),
-    ]),
-  );
-
-  const innerReturn = ts.createReturn(ts.createIdentifier(name));
-
-  // NOTE: TS 2.4+ has a create IIFE helper method
-  const iife = ts.createCall(
-    ts.createParen(
-      ts.createFunctionExpression(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        [],
-        undefined,
-        ts.createBlock([
-          innerVarStmt,
-          ...statements,
-          innerReturn,
-        ]),
-      ),
-    ),
-    undefined,
-    [],
-  );
 
   // Update existing host node with the pure comment before the variable declaration initializer.
   const variableDeclaration = hostNode.declarationList.declarations[0];
@@ -381,7 +347,10 @@ function createWrappedEnum(
           variableDeclaration.name,
           variableDeclaration.type,
           ts.addSyntheticLeadingComment(
-            iife, ts.SyntaxKind.MultiLineCommentTrivia, pureFunctionComment, false,
+            expression,
+            ts.SyntaxKind.MultiLineCommentTrivia,
+            pureFunctionComment,
+            false,
           ),
         ),
       ],
@@ -389,4 +358,66 @@ function createWrappedEnum(
   );
 
   return outerVarStmt;
+}
+
+function updateEnumIife(hostNode: ts.VariableStatement, iife: ts.CallExpression): ts.Statement {
+  if (!ts.isParenthesizedExpression(iife.expression)
+      || !ts.isFunctionExpression(iife.expression.expression)) {
+    throw new Error('Invalid IIFE Structure');
+  }
+
+  const expression = iife.expression.expression;
+  const updatedFunction = ts.updateFunctionExpression(
+    expression,
+    expression.modifiers,
+    expression.asteriskToken,
+    expression.name,
+    expression.typeParameters,
+    expression.parameters,
+    expression.type,
+    ts.updateBlock(
+      expression.body,
+      [
+        ...expression.body.statements,
+        ts.createReturn(expression.parameters[0].name as ts.Identifier),
+      ],
+    ),
+  );
+
+  const updatedIife = ts.updateCall(
+    iife,
+    ts.updateParen(
+      iife.expression,
+      updatedFunction,
+    ),
+    iife.typeArguments,
+    [ts.createObjectLiteral()],
+  );
+
+  return updateHostNode(hostNode, updatedIife);
+}
+
+function createWrappedEnum(
+  name: string,
+  hostNode: ts.VariableStatement,
+  statements: Array<ts.Statement>,
+  literalInitializer: ts.ObjectLiteralExpression | undefined,
+): ts.Statement {
+  literalInitializer = literalInitializer || ts.createObjectLiteral();
+  const innerVarStmt = ts.createVariableStatement(
+    undefined,
+    ts.createVariableDeclarationList([
+      ts.createVariableDeclaration(name, undefined, literalInitializer),
+    ]),
+  );
+
+  const innerReturn = ts.createReturn(ts.createIdentifier(name));
+
+  const iife = ts.createImmediatelyInvokedFunctionExpression([
+    innerVarStmt,
+    ...statements,
+    innerReturn,
+  ]);
+
+  return updateHostNode(hostNode, ts.createParen(iife));
 }

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
@@ -30,7 +30,7 @@ describe('wrap-enums', () => {
         ChangeDetectionStrategy[ChangeDetectionStrategy.OnPush] = "OnPush";
         ChangeDetectionStrategy[ChangeDetectionStrategy.Default] = "Default";
         return ChangeDetectionStrategy;
-      })();
+      }());
     `;
 
     expect(testWrapEnums(input)).toBeTruthy();
@@ -46,12 +46,11 @@ describe('wrap-enums', () => {
       })(ChangeDetectionStrategy || (ChangeDetectionStrategy = {}));
     `;
     const output = tags.stripIndent`
-      export var ChangeDetectionStrategy = /*@__PURE__*/ (function () {
-        var ChangeDetectionStrategy = {};
+      export var ChangeDetectionStrategy = /*@__PURE__*/ (function (ChangeDetectionStrategy) {
         ChangeDetectionStrategy[ChangeDetectionStrategy["OnPush"] = 0] = "OnPush";
         ChangeDetectionStrategy[ChangeDetectionStrategy["Default"] = 1] = "Default";
         return ChangeDetectionStrategy;
-      })();
+      })({});
     `;
 
     expect(testWrapEnums(input)).toBeTruthy();
@@ -85,7 +84,7 @@ describe('wrap-enums', () => {
         FormatWidth[FormatWidth.Long] = "Long";
         FormatWidth[FormatWidth.Full] = "Full";
         return FormatWidth;
-      })();
+      }());
     `;
 
     expect(testWrapEnums(input)).toBeTruthy();


### PR DESCRIPTION
This eliminates several array copying operations as well as making the changes in the 2.3+ case more surgical (i.e., direct minimal modification of the existing IIFE).  The tsickle case is also now more robust.

Fixes https://github.com/angular/angular-cli/issues/8536