### PR TITLE
Build Optimizer Lightweight Transformations

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -88,17 +88,6 @@ describe('build-optimizer', () => {
       });
     });
 
-    it('doesn\'t process files without decorators/ctorParameters/outside Angular', () => {
-      const input = tags.oneLine`
-        var Clazz = (function () { function Clazz() { } return Clazz; }());
-        ${staticProperty}
-      `;
-
-      const boOutput = buildOptimizer({ content: input });
-      expect(boOutput.content).toBeFalsy();
-      expect(boOutput.emitSkipped).toEqual(true);
-    });
-
     it('supports es2015 modules', () => {
       // prefix-functions would add PURE_IMPORTS_START and PURE to the super call.
       // This test ensures it isn't applied to es2015 modules.

--- a/packages/angular_devkit/build_optimizer/src/transforms/class-fold_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/class-fold_spec.ts
@@ -11,7 +11,7 @@ import { getFoldFileTransformer } from './class-fold';
 
 
 const transform = (content: string) => transformJavascript(
-  { content, getTransforms: [getFoldFileTransformer] }).content;
+  { content, getTransforms: [getFoldFileTransformer], typeCheck: true }).content;
 
 describe('class-fold', () => {
   it('folds static properties into class', () => {

--- a/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/scrub-file_spec.ts
@@ -11,7 +11,7 @@ import { getScrubFileTransformer, testScrubFile } from './scrub-file';
 
 
 const transform = (content: string) => transformJavascript(
-  { content, getTransforms: [getScrubFileTransformer] }).content;
+  { content, getTransforms: [getScrubFileTransformer], typeCheck: true }).content;
 
 describe('scrub-file', () => {
   const clazz = 'var Clazz = (function () { function Clazz() { } return Clazz; }());';


### PR DESCRIPTION
This provides a transformation fast path when source maps are not enabled and transformers that require the type checker are not needed for a file (`scrub-file`/`fold-file`).  This also has the advantage of not running any of the built-in (and unneeded) transformers when used.
There doesn't appear to be a publicly exposed mechanism to generate source maps with the TS printer.  If this were possible, the source map limitation could be lifted.