### PR TITLE
fix(@angular-devkit/schematics): create directory when moving file

### DIFF
--- a/packages/angular_devkit/schematics/src/sink/filesystem.ts
+++ b/packages/angular_devkit/schematics/src/sink/filesystem.ts
@@ -84,6 +84,8 @@ export class FileSystemSinkHost implements VirtualFileSystemSinkHost {
     to = join(this._root, to);
 
     return new Observable<void>(o => {
+      this.mkDir(dirname(to));
+
       fs.rename(from, to, err => {
         if (err) {
           o.error(err);

--- a/packages/angular_devkit/schematics/src/sink/filesystem_spec.ts
+++ b/packages/angular_devkit/schematics/src/sink/filesystem_spec.ts
@@ -122,6 +122,21 @@ describe('FileSystemSink', () => {
           .then(done, done.fail);
     });
 
+
+    it('can rename nested files', done => {
+      const tree = new FileSystemTree(new FileSystemHost(outputRoot));
+      tree.rename('/sub/directory/file2', '/another-directory/file2');
+
+      const sink = new FileSystemSink(outputRoot);
+      sink.commit(optimize(tree))
+          .toPromise()
+          .then(() => {
+            expect(fs.existsSync(join(outputRoot, '/sub/directory/file2'))).toBe(false);
+            expect(fs.existsSync(join(outputRoot, '/another-directory/file2'))).toBe(true);
+          })
+          .then(done, done.fail);
+    });
+
     it('can delete and create the same file', done => {
       const tree = new FileSystemTree(new FileSystemHost(outputRoot));
       tree.delete('/file0');


### PR DESCRIPTION
If the destination directory is not present, the moving of the file would fail. That's why we need to ensure the directory exists before the move/rename.

fixes #352