### PR TITLE
fix(@schematics/angular): fix import path for generated flat modules

### DIFF
--- a/packages/schematics/angular/module/index.ts
+++ b/packages/schematics/angular/module/index.ts
@@ -53,7 +53,7 @@ function addDeclarationToNgModule(options: ModuleOptions): Rule {
     );
     const relativeDir = relative(dirname(modulePath), dirname(importModulePath));
     const relativePath = (relativeDir.startsWith('.') ? relativeDir : './' + relativeDir)
-      + '/' + basename(importModulePath);
+      + (relativeDir.length === 0 ? '' : '/') + basename(importModulePath);
     const changes = addImportToModule(source, modulePath,
                                       strings.classify(`${options.name}Module`),
                                       relativePath);

--- a/packages/schematics/angular/module/index_spec.ts
+++ b/packages/schematics/angular/module/index_spec.ts
@@ -55,6 +55,22 @@ describe('Module Schematic', () => {
     expect(files.indexOf('/projects/bar/src/app/foo/foo.module.ts')).toBeGreaterThanOrEqual(0);
   });
 
+  it('should import a generated flat module with a correct relative path', () => {
+    const options = {
+      ...defaultOptions,
+      appRoot: 'app',
+      module: 'app',
+      flat: true,
+    };
+
+    const tree = schematicRunner.runSchematic('module', options, appTree);
+    const files = tree.files;
+    expect(files.indexOf('/projects/bar/src/app/app.module.ts')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/projects/bar/src/app/foo.module.ts')).toBeGreaterThanOrEqual(0);
+    const moduleContent = tree.readContent('/projects/bar/src/app/app.module.ts');
+    expect(moduleContent).toMatch(/import { FooModule } from '\.\/foo.module'/);
+  });
+
   it('should import into another module', () => {
     const options = { ...defaultOptions, module: 'app.module.ts' };
 


### PR DESCRIPTION
If the target modulePath and the importModulePath are equal,
do not add a path seperator to the resulting module import path.