### PR TITLE
fix(@schematics/angular): Clear polyfills for universal apps.

### DIFF
--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -51,6 +51,7 @@ function updateConfigFile(options: UniversalOptions): Rule {
       test: options.test,
       tsconfig: tsCfg,
       testTsconfig: testTsCfg,
+      polyfills: undefined,
     };
     if (options.name) {
       serverApp.name = options.name;

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -90,6 +90,7 @@ describe('Universal Schematic', () => {
     expect(app.tsconfig).toEqual('tsconfig.server.json');
     expect(app.testTsconfig).toEqual('tsconfig.spec.json');
     expect(app.environmentSource).toEqual('environments/environment.ts');
+    expect(app.polyfills).not.toBeDefined();
   });
 
   it('should add a server transition to BrowerModule import', () => {


### PR DESCRIPTION
Fixes #324