### PR TITLE
fix(@schematics/angular): Add support for ES2017 proposals

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
@@ -34,7 +34,7 @@
 // import 'core-js/es6/weak-map';
 // import 'core-js/es6/set';
 
-// Support for ES7 Proposals
+// Support for ES2017 Proposals
 // import 'core-js/stage/4';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */

--- a/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
@@ -34,6 +34,9 @@
 // import 'core-js/es6/weak-map';
 // import 'core-js/es6/set';
 
+// Support for ES7 Proposals
+// import 'core-js/stage/4';
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 


### PR DESCRIPTION
Add support for ES7 proposals such as Object.values and Object.entries, fixes angular/angular-cli#9111