### PR TITLE
feat(test): use new zone-testing import from zone.js 0.8.19

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/test.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/test.ts
@@ -1,11 +1,6 @@
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
-import 'zone.js/dist/long-stack-trace-zone';
-import 'zone.js/dist/proxy.js';
-import 'zone.js/dist/sync-test';
-import 'zone.js/dist/jasmine-patch';
-import 'zone.js/dist/async-test';
-import 'zone.js/dist/fake-async-test';
+import 'zone.js/dist/zone-testing';
 import { getTestBed } from '@angular/core/testing';
 import {
   BrowserDynamicTestingModule,

--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -24,7 +24,7 @@
     "@angular/service-worker": "^5.1.0",<% } %>
     "core-js": "^2.4.1",
     "rxjs": "^5.5.2",
-    "zone.js": "^0.8.14"
+    "zone.js": "^0.8.19"
   },
   "devDependencies": {
     "@angular/cli": "<%= version %>",


### PR DESCRIPTION
zone.js 0.8.19 provide a `zone-testing` bundle to import 

```javascript
import '../zone-spec/long-stack-trace';
import '../zone-spec/proxy';
import '../zone-spec/sync-test';
import '../jasmine/jasmine';
import '../zone-spec/async-test';
import '../zone-spec/fake-async-test';
```

so  `angular/cli` only need to import `zone.js/dist/zone-testing`, it will also resolve some 
auto load order change issue.

@clydin, should I make this pull request in this repo? please review, thank you.