### PR TITLE
refactor(@schematics/angular): remove obsolete logic for Karma start …

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/test.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/test.ts
@@ -7,12 +7,7 @@ import {
   platformBrowserDynamicTesting
 } from '@angular/platform-browser-dynamic/testing';
 
-// Unfortunately there's no typing for the `__karma__` variable. Just declare it as any.
-declare const __karma__: any;
 declare const require: any;
-
-// Prevent Karma from running prematurely.
-__karma__.loaded = function () {};
 
 // First, initialize the Angular testing environment.
 getTestBed().initTestEnvironment(
@@ -23,5 +18,3 @@ getTestBed().initTestEnvironment(
 const context = require.context('./', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
-// Finally, start Karma to run the tests.
-__karma__.start();


### PR DESCRIPTION
…delay

Back in the days, when SystemJS was used to load test bundles it was needed to delay test run until SystemJS will load code and test environment will be initialized. It is not the case anymore and probably should have been removed completely in https://github.com/angular/angular-cli/commit/150b3b0eb65cfb257415baae8bb2c946659e5011. 

See [karma-context.html](https://github.com/angular/angular-cli/blob/master/packages/%40angular/cli/plugins/karma-context.html) for more context (pun intended). Browser executes scripts synchronously one after another and since now call to `initTestEnvironment()` is performed synchronously it is guaranteed to complete by the time `window.__karma__.loaded()` is executed. It was not the case with `System.import` (see commit above for original code) because it involved asynchronous loading of test bundles and `initTestEnvironment()` was not guaranteed to complete before `window.__karma__.loaded()` is called.