### PR TITLE
fix(@angular-devkit/schematics): add a backward compatible function

### DIFF
--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -39,6 +39,10 @@ export type SchematicDescription<CollectionMetadataT extends object,
  */
 export interface EngineHost<CollectionMetadataT extends object, SchematicMetadataT extends object> {
   createCollectionDescription(name: string): CollectionDescription<CollectionMetadataT>;
+  /**
+   * @deprecated Use `listSchematicNames`.
+   */
+  listSchematics(collection: Collection<CollectionMetadataT, SchematicMetadataT>): string[];
   listSchematicNames(collection: CollectionDescription<CollectionMetadataT>): string[];
 
   createSchematicDescription(

--- a/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
@@ -6,11 +6,13 @@
  * found in the LICENSE file at https://angular.io/license
  */
 import {
+  Collection,
   CollectionDescription,
   EngineHost,
   RuleFactory,
   SchematicDescription,
-  Source, TypedSchematicContext,
+  Source,
+  TypedSchematicContext,
   UnknownCollectionException,
 } from '@angular-devkit/schematics';
 import { Observable } from 'rxjs/Observable';
@@ -88,6 +90,15 @@ export class FallbackEngineHost implements EngineHost<{}, {}> {
     return (Observable.of(options)
       .pipe(...this._hosts.map(host => mergeMap(opt => host.transformOptions(schematic, opt))))
     ) as {} as Observable<ResultT>;
+  }
+
+  /**
+   * @deprecated Use `listSchematicNames`.
+   */
+  listSchematics(
+    collection: Collection<FallbackCollectionDescription, FallbackSchematicDescription>,
+  ): string[] {
+    return this.listSchematicNames(collection.description);
   }
 
   listSchematicNames(collection: CollectionDescription<FallbackCollectionDescription>): string[] {

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host-base.ts
@@ -18,6 +18,7 @@ import { Observable } from 'rxjs/Observable';
 import { mergeMap } from 'rxjs/operators/mergeMap';
 import { Url } from 'url';
 import {
+  FileSystemCollection,
   FileSystemCollectionDesc,
   FileSystemCollectionDescription,
   FileSystemSchematicContext,
@@ -90,6 +91,12 @@ export abstract class FileSystemEngineHostBase implements
 
   private _transforms: OptionTransform<object, object>[] = [];
 
+  /**
+   * @deprecated Use `listSchematicNames`.
+   */
+  listSchematics(collection: FileSystemCollection): string[] {
+    return this.listSchematicNames(collection.description);
+  }
   listSchematicNames(collection: FileSystemCollectionDescription) {
     const schematics: string[] = [];
     for (const key of Object.keys(collection.schematics)) {


### PR DESCRIPTION
listSchematics was removed and shouldnt have been. Oops.