### PR TITLE
remove deprecated typeof-compare  from tslint.json

### DIFF
--- a/packages/schematics/angular/application/files/tslint.json
+++ b/packages/schematics/angular/application/files/tslint.json
@@ -107,7 +107,6 @@
         "variable-declaration": "nospace"
       }
     ],
-    "typeof-compare": true,
     "unified-signatures": true,
     "variable-name": false,
     "whitespace": [


### PR DESCRIPTION
I hope this is the file that is used as `tslint.json` while creating new projects with angular-cli

The `typeof-compare` has been deprecated/redundant since `tslint 5.9.1`. Hence removing it

tslint v5.9.1 Changelog: https://github.com/palantir/tslint/releases/tag/5.9.1