### PR TITLE
feat(@angular-devkit/schematics-cli): add flag to print the schematic schema

### DIFF
--- a/packages/angular_devkit/schematics_cli/bin/schematics.ts
+++ b/packages/angular_devkit/schematics_cli/bin/schematics.ts
@@ -102,28 +102,28 @@ function parseSchematicName(str: string | null): { collection: string, schematic
 
 /**
  * Displays descriptions for each one of the properties inside a Schematic's Schema.
- * 
+ *
  * The print format is a follows:
  *   --<%= propName %> (<%= type %>): (Default: <%= default %>) (<%= required %>) <%= description %>
  *     alias: -<%= alias =>
- * 
+ *
  * A property is not printed if "visible":"false"
- * 
+ *
  * All keys different than "type", "default", "required", "description" or "alias" won't be printed.
- * 
+ *
  * @param schematicSchema The schematic's schema as a json object
  */
 function printSchematicSchema(schematicSchema: JsonObject) {
-  let props = schematicSchema.properties as JsonObject;
+  const props = schematicSchema.properties as JsonObject;
   let msg = '';
   for (const key in props) {
-    let prop = props[key] as JsonObject;
+    const prop = props[key] as JsonObject;
     if (typeof prop.visible === 'undefined' || prop.visible) {
       let mainInfo = `  --${key}`;
       if (prop.type) {
         mainInfo += ` (${prop.type})`;
       }
-      if (prop.default){
+      if (prop.default) {
         mainInfo += ` (Default: ${prop.default})`;
       }
       msg += terminal.cyan(mainInfo);


### PR DESCRIPTION
This PR adds support to print the schematic's schema using the proposed `--schema` flag. It's known that each schema property key can be named with any arbitrary string, but the print algorithm will just take some of the most known: "type", "default", "required", "description" and "alias". All keys different from those will not be printed, only the property name.

I tried to follow the same coloring format from `ng help`.

This is how it looks rendered in the console:

<img width="885" alt="screen shot 2018-01-13 at 10 34 03 pm" src="https://user-images.githubusercontent.com/3689856/34912546-1e6a3f62-f8b2-11e7-9f18-45139ce179fc.png">

I wanted to print "enums" as well as it seems like it's important, but I still can't wrap my head around how to render that. Any suggestions welcome.

Note: I didn't build any unit test because I didn't find any for flags like `--list-schematics` or `--help` so I'm not really sure if you are contemplating unit testing on these things or not. Happy to do it, just need some direction.

Closes https://github.com/angular/devkit/issues/311