### PR TITLE
docs: add schematics-cli package to supported commit scopes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,6 +197,7 @@ The following is the list of supported scopes:
 * **@angular-devkit/core**
 * **@angular-devkit/build-optimizer**
 * **@angular-devkit/schematics**
+* **@angular-devkit/schematics-cli**
 * **@schematics/angular**
 * **@schematics/schematics**
 


### PR DESCRIPTION
The motivation to allow the `@angular-devkit/schematics-cli` package as a scope in the commit message is because of PRs like this: https://github.com/angular/devkit/pull/391. It's very likely that more changes will be added to this package in the future.