### PR TITLE
feat(@schematics/angular): upgrade to ng 5.2.0

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -45,6 +45,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",<% } %>
-    "typescript": "~2.6.2"
+    "typescript": "~2.5.3"
   }
 }

--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -12,24 +12,24 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^5.1.0",
-    "@angular/common": "^5.1.0",
-    "@angular/compiler": "^5.1.0",
-    "@angular/core": "^5.1.0",
-    "@angular/forms": "^5.1.0",
-    "@angular/http": "^5.1.0",
-    "@angular/platform-browser": "^5.1.0",
-    "@angular/platform-browser-dynamic": "^5.1.0",
-    "@angular/router": "^5.1.0",<% if (serviceWorker) { %>
-    "@angular/service-worker": "^5.1.0",<% } %>
+    "@angular/animations": "^5.2.0",
+    "@angular/common": "^5.2.0",
+    "@angular/compiler": "^5.2.0",
+    "@angular/core": "^5.2.0",
+    "@angular/forms": "^5.2.0",
+    "@angular/http": "^5.2.0",
+    "@angular/platform-browser": "^5.2.0",
+    "@angular/platform-browser-dynamic": "^5.2.0",
+    "@angular/router": "^5.2.0",<% if (serviceWorker) { %>
+    "@angular/service-worker": "^5.2.0",<% } %>
     "core-js": "^2.4.1",
     "rxjs": "^5.5.6",
     "zone.js": "^0.8.19"
   },
   "devDependencies": {
     "@angular/cli": "<%= version %>",
-    "@angular/compiler-cli": "^5.1.0",
-    "@angular/language-service": "^5.1.0",<% if (!minimal) { %>
+    "@angular/compiler-cli": "^5.2.0",
+    "@angular/language-service": "^5.2.0",<% if (!minimal) { %>
     "@types/jasmine": "~2.8.3",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",
@@ -45,6 +45,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.9.1",<% } %>
-    "typescript": "~2.5.3"
+    "typescript": "~2.6.2"
   }
 }

--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -43,7 +43,7 @@
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "protractor": "~5.1.2",
-    "ts-node": "~3.2.0",
+    "ts-node": "~4.1.0",
     "tslint": "~5.9.1",<% } %>
     "typescript": "~2.6.2"
   }


### PR DESCRIPTION
ng 5.2.x released ~~and supports typescript 2.6.x as well~~. 

More details here at - 
https://blog.angular.io/angular-5-2-now-available-312d1099bd81 . 

Upgrade the generated package.json to refer to 5.2.x 
