### PR TITLE
feat(@schematics/angular): strict TypeScript

### DIFF
--- a/packages/schematics/angular/application/files/tsconfig.json
+++ b/packages/schematics/angular/application/files/tsconfig.json
@@ -14,6 +14,10 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ],
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true
   }
 }


### PR DESCRIPTION
Enable currently TS strict features supported by Angular.

**Why this PR ?**

Lately, I gave several advanced Angular courses, with developers working with Angular for more than one year. Each time, they were not aware of the strict features of TypeScript and their projects were in non-strict mode.

TypeScript is not in strict mode by default for compatibility reasons, and to be transparent with standard JavaScript. But strict is the recommanded way to do.

One of the main reasons frameworks like Angular choose TypeScript is for error management, because in an app, you can't do quick JavaScript anymore, with no error management, like we were doing during the jQuery era. A single error can break an app.

Then, using TypeScript in Angular in non strict mode is quite a non sense : several parts of your app won't be checked correctly, and thus may contain errors, wrecking all the efforts to code well in the other parts which are checked correctly.

So strict mode should be the default.

But another problem is strict mode config is becoming difficult : we can't just enable `strict` like in #218, because Angular needs time to update to new TS versions. So currently developers have to enable strict features one by one : there are already 4 in TS 2.5, there will be 5 in TS 2.6 and 6 in TS 2.7.

So it would be really better the CLI enables them by default.

**Consequences for current projects**

None. This schematic is only applied for new apps, so current apps won't break.

@hansl @filipesilva @Brocco 