### PR TITLE
feat(@angular-devkit/schematics): support collection extension

### DIFF
--- a/packages/angular_devkit/schematics/collection-schema.json
+++ b/packages/angular_devkit/schematics/collection-schema.json
@@ -4,6 +4,22 @@
   "title": "Collection Schema for validating a 'collection.json'.",
   "type": "object",
   "properties": {
+    "extends": {
+      "oneOf": [
+        {
+          "type": "string",
+          "minLength": 1
+        },
+        {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "minItems": 1
+        }
+      ]
+    },
     "schematics": {
       "type": "object",
       "description": "A map of schematic names to schematic details",

--- a/packages/angular_devkit/schematics/src/engine/collection.ts
+++ b/packages/angular_devkit/schematics/src/engine/collection.ts
@@ -12,7 +12,8 @@ import { Collection, CollectionDescription, Schematic } from './interface';
 export class CollectionImpl<CollectionT extends object, SchematicT extends object>
     implements Collection<CollectionT, SchematicT> {
   constructor(private _description: CollectionDescription<CollectionT>,
-              private _engine: SchematicEngine<CollectionT, SchematicT>) {
+              private _engine: SchematicEngine<CollectionT, SchematicT>,
+              public readonly baseDescriptions?: Array<CollectionDescription<CollectionT>>) {
   }
 
   get description() { return this._description; }

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -19,6 +19,7 @@ import { TaskConfigurationGenerator, TaskExecutor, TaskId } from './task';
  */
 export type CollectionDescription<CollectionMetadataT extends object> = CollectionMetadataT & {
   readonly name: string;
+  readonly extends?: string[];
 };
 
 /**
@@ -49,7 +50,7 @@ export interface EngineHost<CollectionMetadataT extends object, SchematicMetadat
   createSchematicDescription(
       name: string,
       collection: CollectionDescription<CollectionMetadataT>):
-        SchematicDescription<CollectionMetadataT, SchematicMetadataT>;
+        SchematicDescription<CollectionMetadataT, SchematicMetadataT> | null;
   getSchematicRuleFactory<OptionT extends object>(
       schematic: SchematicDescription<CollectionMetadataT, SchematicMetadataT>,
       collection: CollectionDescription<CollectionMetadataT>): RuleFactory<OptionT>;
@@ -108,6 +109,7 @@ export interface Engine<CollectionMetadataT extends object, SchematicMetadataT e
  */
 export interface Collection<CollectionMetadataT extends object, SchematicMetadataT extends object> {
   readonly description: CollectionDescription<CollectionMetadataT>;
+  readonly baseDescriptions?: Array<CollectionDescription<CollectionMetadataT>>;
 
   createSchematic(name: string): Schematic<CollectionMetadataT, SchematicMetadataT>;
   listSchematicNames(): string[];

--- a/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
+++ b/packages/angular_devkit/schematics/tools/fallback-engine-host.ts
@@ -68,8 +68,11 @@ export class FallbackEngineHost implements EngineHost<{}, {}> {
   createSchematicDescription(
     name: string,
     collection: CollectionDescription<FallbackCollectionDescription>,
-  ): SchematicDescription<FallbackCollectionDescription, FallbackSchematicDescription> {
+  ): SchematicDescription<FallbackCollectionDescription, FallbackSchematicDescription> | null {
     const description = collection.host.createSchematicDescription(name, collection.description);
+    if (!description) {
+      return null;
+    }
 
     return { name, collection, description };
   }

--- a/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
+++ b/packages/angular_devkit/schematics/tools/file-system-engine-host_spec.ts
@@ -39,6 +39,163 @@ describe('FileSystemEngineHost', () => {
     expect(schematic1.description.name).toBe('schematic1');
   });
 
+  it('lists schematics but not aliases', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('aliases');
+    const names = testCollection.listSchematicNames();
+
+    expect(names).not.toBeNull();
+    expect(names[0]).toBe('schematic1');
+    expect(names[1]).toBe('schematic2');
+  });
+
+  it('extends a collection with string', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('extends-basic-string');
+
+    expect(testCollection.baseDescriptions).not.toBeUndefined();
+    expect(testCollection.baseDescriptions
+           && testCollection.baseDescriptions.length).toBe(1);
+
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+
+    const schematic2 = engine.createSchematic('schematic2', testCollection);
+
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic2');
+
+    const names = testCollection.listSchematicNames();
+
+    expect(names.length).toBe(2);
+  });
+
+  it('extends a collection with array', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('extends-basic');
+
+    expect(testCollection.baseDescriptions).not.toBeUndefined();
+    expect(testCollection.baseDescriptions
+           && testCollection.baseDescriptions.length).toBe(1);
+
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+
+    const schematic2 = engine.createSchematic('schematic2', testCollection);
+
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic2');
+
+    const names = testCollection.listSchematicNames();
+
+    expect(names.length).toBe(2);
+  });
+
+  it('extends a collection with full depth', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('extends-deep');
+
+    expect(testCollection.baseDescriptions).not.toBeUndefined();
+    expect(testCollection.baseDescriptions
+           && testCollection.baseDescriptions.length).toBe(2);
+
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+
+    const schematic2 = engine.createSchematic('schematic2', testCollection);
+
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic2');
+
+    const names = testCollection.listSchematicNames();
+
+    expect(names.length).toBe(2);
+  });
+
+  it('replaces base schematics when extending', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('extends-replace');
+
+    expect(testCollection.baseDescriptions).not.toBeUndefined();
+    expect(testCollection.baseDescriptions
+           && testCollection.baseDescriptions.length).toBe(1);
+
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+    expect(schematic1.description.description).toBe('replaced');
+
+    const names = testCollection.listSchematicNames();
+
+    expect(names).not.toBeNull();
+    expect(names.length).toBe(1);
+  });
+
+  it('extends multiple collections', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    const testCollection = engine.createCollection('extends-multiple');
+
+    expect(testCollection.baseDescriptions).not.toBeUndefined();
+    expect(testCollection.baseDescriptions
+           && testCollection.baseDescriptions.length).toBe(4);
+
+    const schematic1 = engine.createSchematic('schematic1', testCollection);
+
+    expect(schematic1).not.toBeNull();
+    expect(schematic1.description.name).toBe('schematic1');
+    expect(schematic1.description.description).toBe('replaced');
+
+    const schematic2 = engine.createSchematic('schematic2', testCollection);
+
+    expect(schematic2).not.toBeNull();
+    expect(schematic2.description.name).toBe('schematic2');
+
+    const names = testCollection.listSchematicNames();
+
+    expect(names).not.toBeNull();
+    expect(names.length).toBe(2);
+  });
+
+  it('errors on simple circular collections', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => engine.createCollection('extends-circular')).toThrow();
+  });
+
+  it('errors on complex circular collections', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => engine.createCollection('extends-circular-multiple')).toThrow();
+  });
+
+  it('errors on deep circular collections', () => {
+    const engineHost = new FileSystemEngineHost(root);
+    const engine = new SchematicEngine(engineHost);
+
+    expect(() => engine.createCollection('extends-circular-deep')).toThrow();
+  });
+
   it('errors on invalid aliases', () => {
     const engineHost = new FileSystemEngineHost(root);
     const engine = new SchematicEngine(engineHost);

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-basic-string/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-basic-string/collection.json
@@ -1,0 +1,10 @@
+{
+  "name": "extends-basic-string",
+  "extends": "works",
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-basic/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-basic/collection.json
@@ -1,0 +1,12 @@
+{
+  "name": "extends-basic",
+  "extends": [
+    "works"
+  ],
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-deep/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-deep/collection.json
@@ -1,0 +1,10 @@
+{
+  "name": "extends-circular-deep",
+  "extends": "extends-circular-multiple",
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-middle/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-middle/collection.json
@@ -1,0 +1,13 @@
+{
+  "name": "extends-circular-middle",
+  "extends": [
+    "extends-multiple",
+    "extends-circular-multiple"
+  ],
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-multiple/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular-multiple/collection.json
@@ -1,0 +1,13 @@
+{
+  "name": "extends-circular-multiple",
+  "extends": [
+    "extends-multiple",
+    "extends-circular-middle"
+  ],
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-circular/collection.json
@@ -1,0 +1,10 @@
+{
+  "name": "extends-circular",
+  "extends": "extends-circular",
+  "schematics": {
+    "schematic2": {
+      "description": "2",
+      "factory": "../null-factory"
+    }
+  }
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-deep/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-deep/collection.json
@@ -1,0 +1,5 @@
+{
+  "name": "extends-deep",
+  "extends": "extends-basic",
+  "schematics": {}
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-multiple/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-multiple/collection.json
@@ -1,0 +1,8 @@
+{
+  "name": "extends-multiple",
+  "extends": [
+    "extends-basic",
+    "extends-replace"
+  ],
+  "schematics": {}
+}

--- a/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-replace/collection.json
+++ b/tests/@angular_devkit/schematics/tools/file-system-engine-host/extends-replace/collection.json
@@ -1,0 +1,12 @@
+{
+  "name": "extends-replace",
+  "extends": [
+    "works"
+  ],
+  "schematics": {
+    "schematic1": {
+      "description": "replaced",
+      "factory": "../null-factory"
+    }
+  }
+}


### PR DESCRIPTION
Example usage (also supports an array of strings):
```{
  "name": "extends-basic-string",
  "extends": "works",
  "schematics": {
    "schematic2": {
      "description": "2",
      "factory": "../null-factory"
    }
  }
}
```

Closes #34 