### PR TITLE
fix - reswitch /core as a dependency and not peer

### DIFF
--- a/packages/schematics/schematics/package.json
+++ b/packages/schematics/schematics/package.json
@@ -12,8 +12,10 @@
     "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
   },
   "schematics": "./collection.json",
+  "dependencies": {
+    "@angular-devkit/core": "0.0.0"
+  },
   "peerDependencies": {
-    "@angular-devkit/core": "0.0.0",
     "@angular-devkit/schematics": "0.0.0"
   }
 }


### PR DESCRIPTION
it's a revert of part of [this commit](https://github.com/angular/devkit/commit/727e179052c264dd60357dba26e1bf362b5a76a6)

ng-cli depends for version ^1.5 depends on /schematics and not on /core, as a result the recent swithc to peer dependency broke build for peoples all other the world

https://github.com/angular/angular-cli/issues/9283

i'm not saying that the move to dependency to peer isn't the right one, im saying that it shouldnt be made in a patch bump