### PR TITLE
feat(@schematics/angular): add flag for IE/Edge to prevent error or performance impact

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
@@ -61,6 +61,12 @@ import 'core-js/es7/reflect';
  // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
  // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
+ /*
+ * in IE/Edge developer tools, the addEventListener will also be wrapped by zone.js
+ * with the following flag, it will bypass `zone.js` patch for IE/Edge
+ */
+// (window as any).__Zone_enable_cross_context_check = true;
+
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.
  */


### PR DESCRIPTION
from `zone.js` 0.8.13, there is a new flag `__Zone_enable_cross_context_check` was added.

- IE/Edge: in Developer tools, `addEventListener` will also be patched by `zone.js`. 
 -  in Edge the performance will be slowed down, and the `performance monitor` data will be wrong because of the `zone.js` patch.
 - in some version of `IE11`, the `addEventListener` will throw exception because of the `security` error.

`zone.js` will check those cases and if the code is run in `IE/Edge` developer tools, just use `native addEventListener` to prevent such kind of performance impact or error.

To do this check, `zone.js` will call `callback.toString()` (callback is the handler in  `addEventListener(eventName, callback);`) , and in `IE/Edge` and some version of `Firefox`, the `callback.toString()` will throw error because of `security` reason.

and the purpose of the `__Zone_enable_cross_context_check` flag is 
- when the flag is true, `zone.js` will catch the `callback.toString()` possible error, and use `native addEventListener`

so in this PR, I add the flag in `polyfill.ts`, user can set the flag to true when user want to debug in `IE/Edge` when development and can set the flag to false in production mode.

I don't know is that possible to know the `dev/prod` mode in `polyfill.ts`, if we can, we can check the mode and only set the flag to true when we are in dev mode.