### PR TITLE
feat(@schematics/angular): add zone.js flags which can disable some patch

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/polyfills.ts
@@ -52,7 +52,14 @@ import 'core-js/es7/reflect';
  **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.
 
+/**
+ * By default, zone.js will patch all possible macroTask and DomEvents
+ * user can disable parts of macroTask/DomEvents patch by setting following flags
+ */
 
+ // (window as any).__Zone_disable_requestAnimationFrame = true; // disable patch requestAnimationFrame
+ // (window as any).__Zone_disable_on_property = true; // disable patch onProperty such as onclick
+ // (window as any).__zone_symbol__BLACK_LISTED_EVENTS = ['scroll', 'mousemove']; // disable patch specified eventNames
 
 /***************************************************************************************************
  * Zone JS is required by default for Angular itself.


### PR DESCRIPTION
in `zone.js`, there are some flags which can disable some monkey-patch.
such as 
- disable requestAnimationFrame
- disable onProperty
...

or disable some eventNames such as 
- disable scroll eventName, mousemove.

which can improve performance and can let user do some customized patch.

- update: 2018/1/23, sync the flag list with `angular.io`, https://github.com/angular/angular/pull/21701