### PR TITLE
fix(@schematics/angular): remove karma-cli

### DIFF
--- a/packages/schematics/angular/application/files/package.json
+++ b/packages/schematics/angular/application/files/package.json
@@ -38,7 +38,6 @@
     "jasmine-spec-reporter": "~4.2.1",
     "karma": "~2.0.0",
     "karma-chrome-launcher": "~2.2.0",
-    "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^1.2.1",
     "karma-jasmine": "~1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",


### PR DESCRIPTION
It is not needed. Only when ejecting which is covered by angular/angular-cli#9368

Fixes angular/angular-cli#9294