### PR TITLE
Build optimizer update

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer.ts
@@ -12,6 +12,7 @@ import {
   transformJavascript,
 } from '../helpers/transform-javascript';
 import { getFoldFileTransformer } from '../transforms/class-fold';
+import { getForcePureCallTransformer, testForcePureCall } from '../transforms/force-pure-call';
 import { getImportTslibTransformer, testImportTslib } from '../transforms/import-tslib';
 import { getPrefixClassesTransformer, testPrefixClasses } from '../transforms/prefix-classes';
 import { getPrefixFunctionsTransformer } from '../transforms/prefix-functions';
@@ -139,6 +140,10 @@ export function buildOptimizer(options: BuildOptimizerOptions): TransformJavascr
 
   if (testWrapEnums(content)) {
     getTransforms.unshift(getWrapEnumsTransformer);
+  }
+
+  if (testForcePureCall(content)) {
+    getTransforms.unshift(getForcePureCallTransformer);
   }
 
   const transformJavascriptOpts: TransformJavascriptOptions = {

--- a/packages/angular_devkit/build_optimizer/src/transforms/force-pure-call.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/force-pure-call.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import * as ts from 'typescript';
+
+
+const pureFunctionComment = '@__PURE__';
+const callExprWhitelist = [
+  'makeDecorator',
+  'makePropDecorator',
+  'makeParamDecorator',
+  'makeMetadataCtor',
+];
+
+export function testForcePureCall(content: string) {
+  // Should match be /\/\*@__PURE__\*\/ (makeDecorator|etc)\(/, where 'etc' is all others in the
+  // whitelist, separated by '|';
+  const regex = [
+    /\/\*@__PURE__\*\/ /,
+    `(${callExprWhitelist.join('|')})`,
+    /\(/,
+  ].map(x => typeof x === 'string' ? x : x.source).join('');
+
+  return new RegExp(regex).test(content);
+}
+
+// This transform exists as a workaround for the following TS issues:
+// - https://github.com/Microsoft/TypeScript/issues/17689
+// - https://github.com/Microsoft/TypeScript/issues/17606
+// It forces call expressions in a whitelist to have a leading PURE comment.
+// Once TS fixes this problem for call expressions, Build Optimizer should be updated and this
+// transform removed.
+export function getForcePureCallTransformer(): ts.TransformerFactory<ts.SourceFile> {
+  return (context: ts.TransformationContext): ts.Transformer<ts.SourceFile> => {
+
+    const transformer: ts.Transformer<ts.SourceFile> = (sf: ts.SourceFile) => {
+
+      const visitor: ts.Visitor = (node: ts.Node): ts.Node => {
+
+        // Check if node is a TS whitelisted call expression and add comment.
+        if (isWhitelistedCallExpression(node)) {
+          const newNode = ts.addSyntheticLeadingComment(
+            node, ts.SyntaxKind.MultiLineCommentTrivia, pureFunctionComment, false);
+
+          // Replace node with modified one.
+          return ts.visitEachChild(newNode, visitor, context);
+        }
+
+        return ts.visitEachChild(node, visitor, context);
+      };
+
+      return ts.visitEachChild(sf, visitor, context);
+    };
+
+    return transformer;
+  };
+}
+
+function isWhitelistedCallExpression(node: ts.Node) {
+  if (!ts.isCallExpression(node)) {
+    return false;
+  }
+
+  if (!ts.isIdentifier(node.expression)) {
+    return false;
+  }
+
+  if (callExprWhitelist.indexOf(node.expression.text) === -1) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/angular_devkit/build_optimizer/src/transforms/force-pure-call_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/force-pure-call_spec.ts
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { tags } from '@angular-devkit/core';
+import { transformJavascript } from '../helpers/transform-javascript';
+import { getForcePureCallTransformer, testForcePureCall } from './force-pure-call';
+
+
+const transform = (content: string) => transformJavascript(
+  { content, getTransforms: [getForcePureCallTransformer] }).content;
+
+describe('force-pure-call', () => {
+  it('forces pure call on makeDecorator', () => {
+    const input = tags.stripIndent`
+      var Component = /*@__PURE__*/ makeDecorator('Component', function (c) {
+          if (c === void 0) { c = {}; }
+          return (Object.assign({ changeDetection: ChangeDetectionStrategy.Default }, c));
+      }, Directive);
+    `;
+
+    expect(testForcePureCall(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${input}`);
+  });
+
+  it('forces pure call on makeDecorator', () => {
+    // tslint:disable:max-line-length
+    const input = tags.stripIndent`
+      var Input = /*@__PURE__*/ makePropDecorator('Input', function (bindingPropertyName) { return ({ bindingPropertyName: bindingPropertyName }); });
+    `;
+
+    expect(testForcePureCall(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${input}`);
+  });
+
+  it('forces pure call on makeDecorator', () => {
+    // tslint:disable:max-line-length
+    const input = tags.stripIndent`
+      var Inject = /*@__PURE__*/ makeParamDecorator('Inject', function (token) { return ({ token: token }); });
+    `;
+
+    expect(testForcePureCall(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${input}`);
+  });
+
+  it('forces pure call on makeDecorator', () => {
+    const input = tags.stripIndent`
+      var /** @type {?} */ metaCtor = /*@__PURE__*/ makeMetadataCtor(props);
+    `;
+
+    expect(testForcePureCall(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${input}`);
+  });
+
+  it('tests false for files that do not have pure call already', () => {
+    const input = tags.stripIndent`
+      var /** @type {?} */ metaCtor = makeMetadataCtor(props);
+    `;
+
+    expect(testForcePureCall(input)).toBeFalsy();
+  });
+});


### PR DESCRIPTION
This transform exists as a workaround for the following TS issues:
- https://github.com/Microsoft/TypeScript/issues/17689
- https://github.com/Microsoft/TypeScript/issues/17606

It forces call expressions in a whitelist to have a leading PURE comment.

Once TS fixes this problem for call expressions, Build Optimizer should be updated and this transform removed.