### PR TITLE
style: Add tslint rule to prevent using non-pipeable imports

### DIFF
--- a/packages/angular_devkit/schematics/src/sink/filesystem.ts
+++ b/packages/angular_devkit/schematics/src/sink/filesystem.ts
@@ -8,7 +8,6 @@
 import * as fs from 'fs';
 import { dirname, join } from 'path';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/concat';  // provides support for CLI < 1.6.5/1.7.0-beta.1
 import { VirtualFileSystemSink, VirtualFileSystemSinkHost } from './virtual-filesystem';
 
 

--- a/tslint.json
+++ b/tslint.json
@@ -14,6 +14,7 @@
       true,
       "rxjs"
     ],
+    "no-import-side-effect": [true, {"ignore-module": "^(?!rxjs\/)"}],
     "align": [
       true,
       "elements",


### PR DESCRIPTION
This should be part of the next minor release, not a patch release as it could cause issues with consumers of the schematics library that are not using pipeable operators.