### PR TITLE
feat(@schematics/angular): add zone-error import in polyfill

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/environments/environment.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/environments/environment.ts
@@ -6,3 +6,11 @@
 export const environment = {
   production: false
 };
+
+/*
+ * In development mode, to ignore zone related error stack frames such as
+ * `zone.run`, `zoneDelegate.invokeTask` for easier debugging, you can
+ * import the following file, but please comment it out in production mode
+ * because it will have performance impact when throw error
+ */
+// import 'zone.js/dist/zone-error';  // Included with Angular CLI.


### PR DESCRIPTION
in `zone.js`, there is a module `zone-error` will monkey-patch global `Error`, and provide

- stack frame with zone name
```javascript
  at a.b.c (vendor.bundle.js: 12345 <angular>)
  at d.e.f (main.bundle.js: 23456 <root>)
```
- ignore zone aware stack frames

without `zone-error`, we will see a lot of zone stack frames.
```javascript
  at zone.run (polyfill.bundle.js: 3424)
  at zoneDelegate.invokeTask (polyfill.bundle.js: 3424)
  at zoneDelegate.runTask (polyfill.bundle.js: 3424)
  at zone.drainMicroTaskQueue (polyfill.bundle.js: 3424)
  at a.b.c (vendor.bundle.js: 12345 <angular>)
  at d.e.f (main.bundle.js: 23456)
```
it is hard to debug.

with `zone-error`, most of zone stack frames will be removed.

```javascript
  at a.b.c (vendor.bundle.js: 12345 <angular>)
  at d.e.f (main.bundle.js: 23456 <root>)
```

## But to provide those functionality, it has performance impact, so please only use it in development mode when you want to easier debug. comment it out when deploy in production mode.