### PR TITLE
fix(main): match styleguide catch callback

### DIFF
--- a/packages/schematics/angular/application/files/__sourcedir__/main.ts
+++ b/packages/schematics/angular/application/files/__sourcedir__/main.ts
@@ -9,4 +9,4 @@ if (environment.production) {
 }
 
 platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+  .catch(err => console.error(err));


### PR DESCRIPTION
https://angular.io/guide/styleguide#style-02-05

In the styleguide rule above the `catch` callback uses `console.error` when the app boostrapping fails. I am updating the template to match.

I wasn't sure if the success `console.log` should also be included but that seems a bit too opinionated.