### PR TITLE
fix(@angular-devkit/schematics): VirtualDirEntry#subdirs & proper testing

### DIFF
--- a/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory.ts
@@ -41,6 +41,10 @@ export class SimpleMemoryHost implements Host<{}> {
   private _watchers = new Map<Path, [HostWatchOptions, Subject<HostWatchEvent>][]>();
 
   protected _isDir(path: Path) {
+    if (path === '/') {
+      return true;
+    }
+
     for (const p of this._cache.keys()) {
       if (p.startsWith(path + NormalizedSep)) {
         return true;

--- a/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/host/memory_spec.ts
@@ -107,6 +107,7 @@ describe('SimpleMemoryHost', () => {
 
     expect(host.isFile(normalize('/sub'))).toBe(false);
     expect(host.isFile(normalize('/sub1'))).toBe(false);
+    expect(host.isDirectory(normalize('/'))).toBe(true);
     expect(host.isDirectory(normalize('/sub'))).toBe(true);
     expect(host.isDirectory(normalize('/sub/sub1'))).toBe(true);
     expect(host.isDirectory(normalize('/sub/file1'))).toBe(false);

--- a/packages/angular_devkit/core/src/virtual-fs/path.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path.ts
@@ -55,7 +55,12 @@ export const NormalizedRoot = NormalizedSep as Path;
  * @returns {Path[]} An array of path fragments.
  */
 export function split(path: Path): PathFragment[] {
-  return path.split(NormalizedSep).map(x => fragment(x));
+  const fragments = path.split(NormalizedSep).map(x => fragment(x));
+  if (fragments[fragments.length - 1].length === 0) {
+    fragments.pop();
+  }
+
+  return fragments;
 }
 
 /**
@@ -89,12 +94,14 @@ export function basename(path: Path): PathFragment {
  * Return the dirname of the path, as a Path. See path.dirname
  */
 export function dirname(path: Path): Path {
-  const i = path.lastIndexOf(NormalizedSep);
-  if (i == -1) {
+  const index = path.lastIndexOf(NormalizedSep);
+  if (index === -1) {
     return '' as Path;
-  } else {
-    return normalize(path.substr(0, i));
   }
+
+  const endIndex = index === 0 ? 1 : index; // case of file under root: '/file'
+
+  return normalize(path.substr(0, endIndex));
 }
 
 

--- a/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
+++ b/packages/angular_devkit/core/src/virtual-fs/path_spec.ts
@@ -85,6 +85,9 @@ describe('path', () => {
       ['a', ['a']],
       ['/a/b', ['', 'a', 'b']],
       ['a/b', ['a', 'b']],
+      ['a/b/', ['a', 'b']],
+      ['', []],
+      ['/', ['']],
     ];
 
     for (const goldens of tests) {
@@ -142,6 +145,7 @@ describe('path', () => {
 
   it('dirname', () => {
     expect(dirname(normalize('a'))).toBe('');
+    expect(dirname(normalize('/a'))).toBe('/');
     expect(dirname(normalize('/a/b/c'))).toBe('/a/b');
     expect(dirname(normalize('./c'))).toBe('');
     expect(dirname(normalize('./a/b/c'))).toBe('a/b');

--- a/packages/angular_devkit/schematics/src/tree/common_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/common_spec.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+// tslint:disable:non-null-operator
+import { normalize } from '@angular-devkit/core';
+import { Tree } from './interface';
+
+
+export interface VisitTestVisitSpec {
+  root: string;
+  expected?: string[];
+  exception?: (spec: {path: string}) => Error;
+  focus?: boolean;
+}
+
+export interface VisitTestSet {
+  name: string;
+  files: string[];
+  visits: VisitTestVisitSpec[];
+  focus?: boolean;
+}
+
+export interface VisitTestSpec {
+  createTree: (paths: string[]) => Tree;
+  sets: VisitTestSet[];
+}
+
+export function testTreeVisit({createTree, sets}: VisitTestSpec) {
+  sets.forEach(({name, files: paths, visits, focus: focusSet}) => {
+    visits.forEach(({root, expected, exception, focus}) => {
+      if (expected == null) { expected = paths; }
+
+      const that = focusSet || focus ? fit : it;
+      that(`can visit: ${name} from ${root}`, () => {
+        const tree = createTree(paths);
+
+        const normalizedRoot = normalize(root);
+
+        if (exception != null) {
+          expect(() => tree.getDir(normalizedRoot).visit(() => {}))
+          .toThrow(exception({path: normalizedRoot}));
+
+          return;
+        }
+
+        const allPaths: string[] = [];
+        tree.getDir(normalizedRoot)
+          .visit((path, entry) => {
+            expect(entry).not.toBeNull();
+            expect(entry!.content.toString()).toEqual(path);
+            allPaths.push(path);
+          });
+
+        expect(allPaths).toEqual(expected!);
+      });
+    });
+  });
+}

--- a/packages/angular_devkit/schematics/src/tree/filesystem_spec.ts
+++ b/packages/angular_devkit/schematics/src/tree/filesystem_spec.ts
@@ -5,8 +5,92 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { normalize, virtualFs } from '@angular-devkit/core';
+// tslint:disable:non-null-operator
+import { PathIsFileException, normalize, virtualFs } from '@angular-devkit/core';
+import { testTreeVisit } from './common_spec';
 import { FileSystemTree } from './filesystem';
+
+
+describe('FileSystemDirEntry', () => {
+  testTreeVisit({
+    createTree: paths => {
+      const files: {[key: string]: string} = {};
+      paths.forEach(path => files[path] = path);
+
+      const host = new virtualFs.test.TestHost(files);
+      const tree = new FileSystemTree(host);
+
+      return tree;
+    },
+    sets: [
+      {
+        name: 'empty',
+        files: [],
+        visits: [
+          {root: '/', expected: []},
+        ],
+      },
+
+      {
+        name: 'file at root',
+        files: ['/file'],
+        visits: [
+          {root: '/'},
+          {root: '/file', exception: ({path}) => new PathIsFileException(path)},
+        ],
+      },
+      {
+        name: 'file under first level folder',
+        // duplicate use case: folder of single file at root
+        files: ['/folder/file'],
+        visits: [
+          {root: '/'},
+          {root: '/folder', expected: ['/folder/file']},
+          {root: '/folder/file', exception: ({path}) => new PathIsFileException(path)},
+          {root: '/wrong', expected: []},
+        ],
+      },
+      {
+        name: 'file under nested folder',
+        // duplicate use case: nested folder of files
+        files: ['/folder/nested_folder/file'],
+        visits: [
+          {root: '/'},
+          {root: '/folder', expected: ['/folder/nested_folder/file']},
+          {root: '/folder/nested_folder', expected: ['/folder/nested_folder/file']},
+          {
+            root: '/folder/nested_folder/file',
+            exception: ({path}) => new PathIsFileException(path),
+          },
+        ],
+      },
+
+      {
+        name: 'nested folders',
+        // duplicate use case: folder of folders at root
+        // duplicate use case: folders of mixed
+        files: [
+          '/folder/nested_folder0/file',
+          '/folder/nested_folder1/folder/file',
+          '/folder/nested_folder2/file',
+          '/folder/nested_folder2/folder/file',
+        ],
+        visits: [
+          {root: '/'},
+          {root: '/folder'},
+          {root: '/folder/nested_folder0', expected: ['/folder/nested_folder0/file']},
+          {root: '/folder/nested_folder1', expected: ['/folder/nested_folder1/folder/file']},
+          {root: '/folder/nested_folder1/folder', expected: ['/folder/nested_folder1/folder/file']},
+          {root: '/folder/nested_folder2', expected: [
+            '/folder/nested_folder2/file',
+            '/folder/nested_folder2/folder/file',
+          ]},
+          {root: '/folder/nested_folder2/folder', expected: ['/folder/nested_folder2/folder/file']},
+        ],
+      },
+    ],
+  });
+});
 
 
 describe('FileSystem', () => {


### PR DESCRIPTION
- the getter `subdirs` in class `VirtualDirEntry` was wrongly implemented,
returning irrelevant data. Make some code common between `subdirs`
and `subfiles` for clarity and DRY respect.
- testing was not done properly either, since a `FileSystemTree` instance was used
(creating corresponding `FileSystemDirEntry` instances) in a test for `VirtualTree`
(and its corresponding model `VirtualDirEntry`). Despite the inheritance,
it wouldn't test it properly. Therefore copy this test as is to the proper file
`filesystem_spec.ts` and slightly adapt it in `virtual_spec.ts` to use the proper
implementations instead.