### PR TITLE
fix(schematics/angular): ignore yarn-error.log

### DIFF
--- a/packages/schematics/angular/application/files/__dot__gitignore
+++ b/packages/schematics/angular/application/files/__dot__gitignore
@@ -31,6 +31,7 @@
 /coverage
 /libpeerconnection.log
 npm-debug.log
+yarn-error.log
 testem.log
 /typings
 


### PR DESCRIPTION
Ignore yarn-error.log file as well as npm-debug.log