### PR TITLE
build: compile with TS 2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -117,7 +117,7 @@
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
       "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
       "requires": {
-        "@types/node": "6.0.96"
+        "@types/node": "8.9.3"
       }
     },
     "@types/glob": {
@@ -145,7 +145,7 @@
       "resolved": "https://registry.npmjs.org/@types/loader-utils/-/loader-utils-1.1.1.tgz",
       "integrity": "sha512-HG9SyNEyGuJXuaEjhoFeaZE1dZscmPx9svXExM/SKsF3Rh9Bdy4sJB7IJFgfYHIy2eWKmAkxGIvrHL+Kk8MEvw==",
       "requires": {
-        "@types/node": "6.0.96",
+        "@types/node": "8.9.3",
         "@types/webpack": "3.8.2"
       }
     },
@@ -176,7 +176,7 @@
       "requires": {
         "@types/caseless": "0.12.1",
         "@types/form-data": "2.2.1",
-        "@types/node": "6.0.96",
+        "@types/node": "8.9.3",
         "@types/tough-cookie": "2.3.2"
       }
     },
@@ -199,16 +199,6 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@types/source-map/-/source-map-0.5.2.tgz",
       "integrity": "sha512-++w4WmMbk3dS3UeHGzAG+xJOSz5Xqtjys/TBkqG3qp3SeWE7Wwezqe5eB7B51cxUyh4PW7bwVotpsLdBK0D8cw=="
-    },
-    "@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-FKjsOVbC6B7bdSB5CuzyHCkK69I="
-    },
-    "@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
     },
     "@types/tapable": {
       "version": "0.2.4",
@@ -4838,14 +4828,6 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
     },
-    "homedir-polyfill": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
-      "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
-    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -7226,6 +7208,7 @@
         "nopt": "4.0.1",
         "npmlog": "4.1.2",
         "rc": "1.2.3",
+        "request": "2.81.0",
         "rimraf": "2.6.2",
         "semver": "5.4.1",
         "tar": "2.2.1",
@@ -7240,6 +7223,36 @@
           "requires": {
             "abbrev": "1.0.9",
             "osenv": "0.1.4"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
           }
         },
         "rimraf": {
@@ -7884,11 +7897,6 @@
       "requires": {
         "error-ex": "1.3.1"
       }
-    },
-    "parse-passwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
     },
     "parseqs": {
       "version": "0.0.5",
@@ -9451,7 +9459,7 @@
       "resolved": "https://registry.npmjs.org/protractor/-/protractor-5.3.0.tgz",
       "integrity": "sha512-8z1TWtc/I9Kn4fkfg87DhkSAi0arul7DHBEeJ70sy66teQAeffjQED1s0Gduigme7hxHRYdYEKbhHYz28fpv5w==",
       "requires": {
-        "@types/node": "6.0.96",
+        "@types/node": "6.0.101",
         "@types/q": "0.0.32",
         "@types/selenium-webdriver": "2.53.43",
         "blocking-proxy": "1.0.1",
@@ -9468,6 +9476,11 @@
         "webdriver-manager": "12.0.6"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "6.0.101",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.101.tgz",
+          "integrity": "sha512-IQ7V3D6+kK1DArTqTBrnl3M+YgJZLw8ta8w3Q9xjR79HaJzMAoTbZ8TNzUTztrkCKPTqIstE2exdbs1FzsYLUw=="
+        },
         "adm-zip": {
           "version": "0.4.7",
           "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.7.tgz",
@@ -11263,7 +11276,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "optional": true
     },
     "style-loader": {
       "version": "0.19.1",
@@ -11653,73 +11667,55 @@
       }
     },
     "ts-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-4.1.0.tgz",
-      "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-5.0.0.tgz",
+      "integrity": "sha512-mlSim/sQS1s5iT3KZEKXRaqsGC7xM2QoxkrhfznZJyou18dl47PTnY7/KMmbGqiVoQrO9Hk53CYpcychF5TNrQ==",
       "requires": {
         "arrify": "1.0.1",
-        "chalk": "2.3.0",
+        "chalk": "2.3.1",
         "diff": "3.4.0",
         "make-error": "1.3.2",
         "minimist": "1.2.0",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.5.0",
-        "tsconfig": "7.0.0",
-        "v8flags": "3.0.1",
+        "source-map-support": "0.5.3",
         "yn": "2.0.0"
       },
       "dependencies": {
         "chalk": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
+          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
           "requires": {
             "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
-            "supports-color": "4.5.0"
+            "supports-color": "5.2.0"
           }
         },
         "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
-        },
-        "strip-bom": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        },
+        "source-map-support": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.3.tgz",
+          "integrity": "sha512-eKkTgWYeBOQqFGXRfKabMFdnWepo51vWqEdoeikaEPFiJC7MCU5j2h4+6Q8npkZTeLGbSyecZvRxiSoWl3rh+w==",
+          "requires": {
+            "source-map": "0.6.1"
+          }
         },
         "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
+          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
           "requires": {
-            "has-flag": "2.0.0"
+            "has-flag": "3.0.0"
           }
-        },
-        "tsconfig": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-          "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-          "requires": {
-            "@types/strip-bom": "3.0.0",
-            "@types/strip-json-comments": "0.0.30",
-            "strip-bom": "3.0.0",
-            "strip-json-comments": "2.0.1"
-          }
-        },
-        "v8flags": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.1.tgz",
-          "integrity": "sha1-3Oj8N5wX2fLJ6e142JzgAFKxt2s=",
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
         }
       }
     },
@@ -11857,9 +11853,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw=="
     },
     "uglify-js": {
       "version": "2.8.29",
@@ -13226,6 +13222,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "yn": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+      "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo="
     },
     "zone.js": {
       "version": "0.8.20",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "integration:build-optimizer": "npm run integration:build-optimizer:simple && npm run integration:build-optimizer:aio",
     "integration:build-optimizer:simple": "cd tests/@angular_devkit/build_optimizer/webpack/simple-app && npm i -q && npm run reinstall-bo && npm run e2e && npm run benchmark",
     "integration:build-optimizer:aio": "cd tests/@angular_devkit/build_optimizer/webpack/aio-app && npm i -q && npm run reinstall-bo && npm run e2e && npm run benchmark",
+    "postinstall": "npm run admin -- patch-dependencies",
     "prepush": "node ./bin/devkit-admin hooks/pre-push"
   },
   "repository": {
@@ -131,9 +132,9 @@
     "tar": "^3.1.5",
     "temp": "^0.8.3",
     "tree-kill": "^1.2.0",
-    "ts-node": "^4.1.0",
-    "tslint": "^5.5.0",
-    "typescript": "~2.6.1",
+    "ts-node": "^5.0.0",
+    "tslint": "^5.9.1",
+    "typescript": "~2.7.2",
     "uglifyjs-webpack-plugin": "^1.1.6",
     "url-loader": "^0.6.2",
     "webpack": "^3.10.0",

--- a/scripts/patch-dependencies.ts
+++ b/scripts/patch-dependencies.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { execSync } from 'child_process';
+import { existsSync, writeFileSync } from 'fs';
+
+const PATCH_LOCK = 'node_modules/rxjs/.patched';
+
+export default function () {
+  if (!existsSync(PATCH_LOCK)) {
+    execSync('patch -p0 -i scripts/patches/rxjs-ts27.patch');
+    execSync('patch -p0 -i scripts/patches/rxjs-typings.patch');
+    writeFileSync(PATCH_LOCK, '');
+  }
+}

--- a/scripts/patches/rxjs-ts27.patch
+++ b/scripts/patches/rxjs-ts27.patch
@@ -1,0 +1,18 @@
+--- node_modules/rxjs/src/observable/dom/AjaxObservable.ts	2017-12-21 16:48:41.000000000 -0500
++++ node_modules/rxjs/src/observable/dom/AjaxObservable.ts	2018-02-20 11:00:21.000000000 -0500
+@@ -462,13 +462,13 @@
+           //IE does not support json as responseType, parse it internally
+           return xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || 'null');
+         } else {
+-          return JSON.parse(xhr.responseText || 'null');
++          return JSON.parse((xhr as any).responseText || 'null');
+         }
+       case 'xml':
+         return xhr.responseXML;
+       case 'text':
+       default:
+-        return  ('response' in xhr) ? xhr.response : xhr.responseText;
++        return  ('response' in xhr) ? xhr.response : (xhr as any).responseText;
+   }
+ }
+

--- a/scripts/patches/rxjs-typings.patch
+++ b/scripts/patches/rxjs-typings.patch
@@ -1,0 +1,10 @@
+--- node_modules/rxjs/Observable.d.ts	2018-02-20 11:24:56.000000000 -0500
++++ node_modules/rxjs/Observable.d.ts	2018-02-20 11:25:21.000000000 -0500
+@@ -69,6 +69,7 @@
+     pipe<A, B, C, D, E, F, G>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>): Observable<G>;
+     pipe<A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): Observable<H>;
+     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>;
++    pipe<R>(...operations: OperatorFunction<T, R>[]): Observable<R>;
+     toPromise<T>(this: Observable<T>): Promise<T>;
+     toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T>;
+     toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,7 @@
     // source in devtools.
     "inlineSources": true,
     "strictNullChecks": true,
-    "target": "es6",
+    "target": "es2016",
     "lib": [
       "es2017"
     ],
@@ -56,6 +56,7 @@
     "node_modules/**/*",
     "packages/schematics/*/*/*files/**/*",
     "tmp/**/*",
+    "scripts/patches/**/*",
     "tests/**/*"
   ]
 }


### PR DESCRIPTION
This adds some temporary patches for rxjs.  Once v6.0 is released and the devkit transitions, we can remove them.