### PR TITLE
feat(@angular-devkit/schematics): add a workflow class that simplifies the whole thing

### DIFF
--- a/packages/angular_devkit/core/src/utils/array.ts
+++ b/packages/angular_devkit/core/src/utils/array.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export function clean<T>(array: Array<T | undefined>): Array<T> {
+  return array.filter(x => x !== undefined) as Array<T>;
+}

--- a/packages/angular_devkit/core/src/utils/index.ts
+++ b/packages/angular_devkit/core/src/utils/index.ts
@@ -8,6 +8,7 @@
 import * as tags from './literals';
 import * as strings from './strings';
 
+export * from './array';
 export * from './object';
 export * from './template';
 export * from './partially-ordered-set';

--- a/packages/angular_devkit/schematics/BUILD
+++ b/packages/angular_devkit/schematics/BUILD
@@ -59,6 +59,7 @@ ts_library(
     module_root = "tools",
     deps = [
         ":schematics",
+        ":tasks",
         "//packages/angular_devkit/core",
         "//packages/angular_devkit/core:node",
         # @deps: rxjs

--- a/packages/angular_devkit/schematics/src/engine/engine.ts
+++ b/packages/angular_devkit/schematics/src/engine/engine.ts
@@ -13,6 +13,7 @@ import { Url } from 'url';
 import { MergeStrategy } from '../tree/interface';
 import { NullTree } from '../tree/null';
 import { empty } from '../tree/static';
+import { Workflow } from '../workflow';
 import { CollectionImpl } from './collection';
 import {
   Collection,
@@ -78,9 +79,10 @@ export class SchematicEngine<CollectionT extends object, SchematicT extends obje
     = new Map<string, Map<string, SchematicImpl<CollectionT, SchematicT>>>();
   private _taskSchedulers = new Array<TaskScheduler>();
 
-  constructor(private _host: EngineHost<CollectionT, SchematicT>) {
+  constructor(private _host: EngineHost<CollectionT, SchematicT>, protected _workflow?: Workflow) {
   }
 
+  get workflow() { return this._workflow || null; }
   get defaultMergeStrategy() { return this._host.defaultMergeStrategy || MergeStrategy.Default; }
 
   createCollection(name: string): Collection<CollectionT, SchematicT> {

--- a/packages/angular_devkit/schematics/src/engine/interface.ts
+++ b/packages/angular_devkit/schematics/src/engine/interface.ts
@@ -9,6 +9,7 @@ import { logging } from '@angular-devkit/core';
 import { Observable } from 'rxjs/Observable';
 import { Url } from 'url';
 import { FileEntry, MergeStrategy, Tree } from '../tree/interface';
+import { Workflow } from '../workflow';
 import { TaskConfigurationGenerator, TaskExecutor, TaskId } from './task';
 
 
@@ -102,6 +103,7 @@ export interface Engine<CollectionMetadataT extends object, SchematicMetadataT e
   executePostTasks(): Observable<void>;
 
   readonly defaultMergeStrategy: MergeStrategy;
+  readonly workflow: Workflow | null;
 }
 
 

--- a/packages/angular_devkit/schematics/src/exception/exception.ts
+++ b/packages/angular_devkit/schematics/src/exception/exception.ts
@@ -33,6 +33,12 @@ export class MergeConflictException extends BaseException {
   }
 }
 
+export class UnsuccessfulWorkflowExecution extends BaseException {
+  constructor() {
+    super('Workflow did not execute successfully.');
+  }
+}
+
 export class UnimplementedException extends BaseException {
   constructor() { super('This function is unimplemented.'); }
 }

--- a/packages/angular_devkit/schematics/src/index.ts
+++ b/packages/angular_devkit/schematics/src/index.ts
@@ -40,9 +40,13 @@ export * from './engine/schematic';
 export * from './sink/dryrun';
 export * from './sink/filesystem';
 export * from './sink/host';
+export * from './sink/sink';
+
 import * as formats from './formats';
 export { formats };
 
+import * as workflow from './workflow';
+export { workflow };
 
 export interface TreeConstructor {
   empty(): TreeInterface;

--- a/packages/angular_devkit/schematics/src/tree/filesystem.ts
+++ b/packages/angular_devkit/schematics/src/tree/filesystem.ts
@@ -173,6 +173,9 @@ export class FileSystemTree extends VirtualTree {
 }
 
 
+export class HostTree extends FileSystemTree {}
+
+
 export class FileSystemCreateTree extends FileSystemTree {
   constructor(host: virtualFs.Host) {
     super(host);

--- a/packages/angular_devkit/schematics/src/workflow/index.ts
+++ b/packages/angular_devkit/schematics/src/workflow/index.ts
@@ -1,0 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export * from './interface';

--- a/packages/angular_devkit/schematics/src/workflow/interface.ts
+++ b/packages/angular_devkit/schematics/src/workflow/interface.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { logging } from '@angular-devkit/core';
+import { Observable } from 'rxjs/Observable';
+
+export interface RequiredWorkflowExecutionContext {
+  collection: string;
+  schematic: string;
+  options: object;
+}
+
+export interface WorkflowExecutionContext extends RequiredWorkflowExecutionContext {
+  debug: boolean;
+  logger: logging.Logger;
+  parentContext?: Readonly<WorkflowExecutionContext>;
+}
+
+export interface Workflow {
+  readonly context: Readonly<WorkflowExecutionContext>;
+
+  execute(
+    options: Partial<WorkflowExecutionContext> & RequiredWorkflowExecutionContext,
+  ): Observable<void>;
+}

--- a/packages/angular_devkit/schematics/tasks/node/index.ts
+++ b/packages/angular_devkit/schematics/tasks/node/index.ts
@@ -11,6 +11,7 @@ import {
   RepositoryInitializerName,
   RepositoryInitializerTaskFactoryOptions,
  } from '../repo-init/options';
+import { RunSchematicName } from '../run-schematic/options';
 
 export class BuiltinTaskExecutor {
   static readonly NodePackage: TaskExecutorFactory<NodePackageTaskFactoryOptions> = {
@@ -21,5 +22,9 @@ export class BuiltinTaskExecutor {
     TaskExecutorFactory<RepositoryInitializerTaskFactoryOptions> = {
     name: RepositoryInitializerName,
     create: (options) => import('../repo-init/executor').then(mod => mod.default(options)),
+  };
+  static readonly RunSchematic: TaskExecutorFactory<{}> = {
+    name: RunSchematicName,
+    create: () => import('../run-schematic/executor').then(mod => mod.default()),
   };
 }

--- a/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { SchematicContext, TaskExecutor } from '../../src';
+import { RunSchematicTaskOptions } from './options';
+
+
+export default function(): TaskExecutor<RunSchematicTaskOptions> {
+  return (options: RunSchematicTaskOptions, context: SchematicContext) => {
+    const maybeWorkflow = context.engine.workflow;
+
+    if (!maybeWorkflow) {
+      throw new Error('Need Workflow to support executing schematics as post tasks.');
+    }
+
+    return maybeWorkflow.execute({
+      collection: options.collection,
+      schematic: options.name,
+      options: options as object,
+    });
+  };
+}

--- a/packages/angular_devkit/schematics/tasks/run-schematic/init-task.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/init-task.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';
+import { RunSchematicName, RunSchematicTaskOptions } from './options';
+
+
+export class RunSchematicTask implements TaskConfigurationGenerator<RunSchematicTaskOptions> {
+  constructor(
+    protected _collection: string,
+    protected _schematic: string,
+    protected _options: object,
+  ) {}
+
+  toConfiguration(): TaskConfiguration<RunSchematicTaskOptions> {
+    return {
+      name: RunSchematicName,
+      options: {
+        collection: this._collection,
+        name: this._schematic,
+        options: this._options,
+      },
+    };
+  }
+}

--- a/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+export const RunSchematicName = 'run-schematic';
+
+export interface RunSchematicTaskOptions {
+  collection: string;
+  name: string;
+  options: object;
+}

--- a/packages/angular_devkit/schematics/tools/index.ts
+++ b/packages/angular_devkit/schematics/tools/index.ts
@@ -9,6 +9,8 @@ export * from './description';
 export * from './file-system-engine-host-base';
 export * from './file-system-host';
 
+export * from './workflow/node-workflow';
+
 export { FileSystemEngineHost } from './file-system-engine-host';
 export { NodeModulesEngineHost } from './node-module-engine-host';
 export { NodeModulesTestEngineHost } from './node-modules-test-engine-host';

--- a/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
+++ b/packages/angular_devkit/schematics/tools/workflow/node-workflow.ts
@@ -1,0 +1,137 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { logging, schema, virtualFs } from '@angular-devkit/core';
+import {
+  DryRunSink,
+  HostSink,
+  HostTree,
+  SchematicEngine,
+  Sink,
+  Tree,
+  UnsuccessfulWorkflowExecution,
+  formats,
+  workflow,
+} from '@angular-devkit/schematics';  // tslint:disable-line:no-implicit-dependencies
+import { Observable } from 'rxjs/Observable';
+import { empty } from 'rxjs/observable/empty';
+import { of } from 'rxjs/observable/of';
+import { _throw } from 'rxjs/observable/throw';
+import { concat, concatMap, ignoreElements, map } from 'rxjs/operators';
+import { NodeModulesEngineHost, validateOptionsWithSchema } from '..';
+import { DryRunEvent } from '../../src/sink/dryrun';
+import { BuiltinTaskExecutor } from '../../tasks/node';
+
+export class NodeWorkflow implements workflow.Workflow {
+  protected _engine: SchematicEngine<{}, {}>;
+  protected _engineHost: NodeModulesEngineHost;
+
+  protected _dryRunSink: DryRunSink;
+  protected _fsSink: Sink;
+
+  protected _context: workflow.WorkflowExecutionContext[];
+
+  constructor(
+    protected _host: virtualFs.Host,
+    protected _options: {
+      force?: boolean;
+      dryRun?: boolean;
+    },
+  ) {
+    /**
+     * Create the SchematicEngine, which is used by the Schematic library as callbacks to load a
+     * Collection or a Schematic.
+     */
+    this._engineHost = new NodeModulesEngineHost();
+    this._engine = new SchematicEngine(this._engineHost);
+
+    // Add support for schemaJson.
+    const registry = new schema.CoreSchemaRegistry(formats.standardFormats);
+    this._engineHost.registerOptionsTransform(validateOptionsWithSchema(registry));
+
+    this._engineHost.registerTaskExecutor(BuiltinTaskExecutor.NodePackage);
+    this._engineHost.registerTaskExecutor(BuiltinTaskExecutor.RepositoryInitializer);
+
+    // We need two sinks if we want to output what will happen, and actually do the work.
+    // Note that fsSink is technically not used if `--dry-run` is passed, but creating the Sink
+    // does not have any side effect.
+    this._dryRunSink = new DryRunSink(this._host, this._options.force);
+    this._fsSink = new HostSink(this._host, this._options.force);
+
+    this._context = [];
+  }
+
+  get context(): Readonly<workflow.WorkflowExecutionContext> {
+    const maybeContext = this._context[this._context.length - 1];
+    if (!maybeContext) {
+      throw new Error('Cannot get context when workflow is not executing...');
+    }
+
+    return maybeContext;
+  }
+  get reporter(): Observable<DryRunEvent> {
+    return this._dryRunSink.reporter;
+  }
+
+  execute(
+    options: Partial<workflow.WorkflowExecutionContext> & workflow.RequiredWorkflowExecutionContext,
+  ): Observable<void> {
+    /** Create the collection and the schematic. */
+    const collection = this._engine.createCollection(options.collection);
+    const schematic = collection.createSchematic(options.schematic);
+
+    let error = false;
+    const dryRunSubscriber = this._dryRunSink.reporter.subscribe(event => {
+      error = error || (event.kind == 'error');
+    });
+
+    const parentContext = this._context[this._context.length - 1];
+    const context = {
+      ...options,
+      debug: options.debug || false,
+      logger: options.logger || new logging.NullLogger(),
+      parentContext,
+    };
+    this._context.push(context);
+
+    return schematic.call(options.options, of(new HostTree(this._host)), {
+      logger: options.logger || new logging.NullLogger(),
+    }).pipe(
+      map(tree => Tree.optimize(tree)),
+      concatMap((tree: Tree) => {
+        return this._dryRunSink.commit(tree).pipe(
+          ignoreElements(),
+          concat(of(tree)),
+        );
+      }),
+      concatMap((tree: Tree) => {
+        dryRunSubscriber.unsubscribe();
+        if (error) {
+          return _throw(new UnsuccessfulWorkflowExecution());
+        }
+        if (this._options.dryRun) {
+          return empty<void>();
+        }
+
+        return this._fsSink.commit(tree);
+      }),
+      concat(new Observable<void>(obs => {
+        if (!this._options.dryRun) {
+          this._engine.executePostTasks().subscribe(obs);
+        } else {
+          obs.complete();
+        }
+      })),
+      ignoreElements(),
+      concat(new Observable(obs => {
+        this._context.pop();
+
+        obs.complete();
+      })),
+    );
+  }
+}


### PR DESCRIPTION
Workflows are complete abstraction of the whole system. This makes it easier to
have tools that dont diverge from the standard definition of schematics. In case
tools have to diverge they can implement their own workflow as well.

Please note that workflows are also recursive. This means that you can execute
a schematic inside another schematic. This will happen in the next commit with
the schematic task.

For now, the workflow is relatively crude. It will be improved over then next
few commits.
