### PR TITLE
fix(@angular-devkit/core): resolving global npm modules was not working is some situations

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,11 +38,14 @@ jobs:
       - restore_cache:
           key: angular_devkit-{{ checksum "package-lock.json" }}
 
+      - run: npm install --no-save
       - run: which node
       - run: 'node -pe "process.execPath"'
       - run: which npm
       - run: npm config get prefix
-      - run: npm install --no-save
+      - run: 'node -pe "try {require.resolve(''npm'');} catch (e) {''''}"'
+      - run: 'ls /usr/local/lib/node_modules'
+      - run: 'ls /home/circleci/.npm-global/node_modules'
       - run: npm run test -- --code-coverage --full
 
   integration:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ jobs:
       - restore_cache:
           key: angular_devkit-{{ checksum "package-lock.json" }}
 
+      - run: which node
+      - run: 'node -pe "process.execPath"'
+      - run: which npm
+      - run: npm config get prefix
       - run: npm install --no-save
       - run: npm run test -- --code-coverage --full
 

--- a/packages/angular_devkit/core/node/resolve.ts
+++ b/packages/angular_devkit/core/node/resolve.ts
@@ -75,11 +75,23 @@ function _getGlobalNodeModules() {
     : path.resolve(globalPrefix || '', 'node_modules');
 }
 
-function _getNpmPrefix(): string | null {
-  const {stdout, error} = childProcess.spawnSync('npm config get prefix', {shell: true});
-  if (error != null) { return null; }
+let npmPrefix: string | null | undefined = undefined;
 
-  return stdout.toString().trim();
+function _getNpmPrefix(): string | null {
+  if (npmPrefix !== undefined) {
+    return npmPrefix;
+  }
+
+  try {
+    const {stdout, error} = childProcess.spawnSync('npm config get prefix', {shell: true});
+    if (error != null) { return null; }
+
+    npmPrefix = stdout.toString().trim();
+  } catch (exception) {
+    npmPrefix = null;
+  }
+
+  return npmPrefix;
 }
 
 


### PR DESCRIPTION
Examples:

- when setting custom npm prefix
- when using nodist under windows (it is actually also setting custom npm prefix)

Therefore, use `npm config get prefix` to get the actual prefix, keep the environment variable `PREFIX` priority and fallback to other methods if not working.