### PR TITLE
build: add CI-specific Bazel settings

### DIFF
--- a/.circleci/bazel.rc
+++ b/.circleci/bazel.rc
@@ -1,0 +1,20 @@
+# These options are enabled when running on CI
+# We do this by copying this file to /etc/bazel.bazelrc at the start of the build.
+
+# Echo all the configuration settings and their source
+build --announce_rc
+
+# Don't be spammy in the logs
+build --noshow_progress
+
+# Don't run manual tests
+test --test_tag_filters=-manual
+
+# Workaround https://github.com/bazelbuild/bazel/issues/3645
+# Bazel doesn't calculate the memory ceiling correctly when running under Docker.
+# Limit Bazel to consuming resources that fit in CircleCI "medium" class which is the default:
+# https://circleci.com/docs/2.0/configuration-reference/#resource_class
+build --local_resources=3072,2.0,1.0
+
+# Retry in the event of flakes
+test --flaky_test_attempts=2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,7 @@ jobs:
     <<: *defaults
     steps:
       - checkout: *post_checkout
+      - run: sudo cp .circleci/bazel.rc /etc/bazel.bazelrc
       - run: bazel run @nodejs//:npm install
       - run: bazel build //packages/...
 


### PR DESCRIPTION
I suspect this will fix the crashes in the TypeScript worker