### PR TITLE
fix(@angular-devkit/schematics): fix order of commit for sinks

### DIFF
--- a/packages/angular_devkit/schematics/src/index.ts
+++ b/packages/angular_devkit/schematics/src/index.ts
@@ -26,6 +26,7 @@ export {
 export * from './exception/exception';
 export * from './tree/interface';
 export * from './rules/base';
+export * from './rules/call';
 export * from './rules/move';
 export * from './rules/random';
 export * from './rules/schematic';

--- a/packages/angular_devkit/schematics/src/sink/dryrun.ts
+++ b/packages/angular_devkit/schematics/src/sink/dryrun.ts
@@ -105,6 +105,9 @@ export class DryRunSink extends HostSink {
 
       this._subject.next({ kind: 'delete', path });
     });
+    this._filesToRename.forEach(([path, to]) => {
+      this._subject.next({ kind: 'rename', path, to });
+    });
     this._filesToCreate.forEach((content, path) => {
       // Check if this is a renaming.
       for (const [_, to] of this._filesToRename) {
@@ -122,9 +125,6 @@ export class DryRunSink extends HostSink {
     });
     this._filesToUpdate.forEach((content, path) => {
       this._subject.next({ kind: 'update', path, content: content.generate() });
-    });
-    this._filesToRename.forEach(([path, to]) => {
-      this._subject.next({ kind: 'rename', path, to });
     });
 
     this._subject.complete();

--- a/packages/angular_devkit/schematics/src/sink/host.ts
+++ b/packages/angular_devkit/schematics/src/sink/host.ts
@@ -70,12 +70,12 @@ export class HostSink extends SimpleSinkBase {
     return concatObservables(
       observableFrom([...this._filesToDelete.values()]).pipe(
         concatMap(path => this._host.delete(path))),
+      observableFrom([...this._filesToRename.entries()]).pipe(
+        concatMap(([_, [path, to]]) => this._host.rename(path, to))),
       observableFrom([...this._filesToCreate.entries()]).pipe(
         concatMap(([path, buffer]) => {
           return this._host.write(path, buffer.generate() as {} as virtualFs.FileBuffer);
         })),
-      observableFrom([...this._filesToRename.entries()]).pipe(
-        concatMap(([_, [path, to]]) => this._host.rename(path, to))),
       observableFrom([...this._filesToUpdate.entries()]).pipe(
         concatMap(([path, buffer]) => {
           return this._host.write(path, buffer.generate() as {} as virtualFs.FileBuffer);


### PR DESCRIPTION
Right now rename(a => b) then create(a) should work, but results in an
error that the file already exist.