### PR TITLE
feat(devkit): add a devkit package schematic

### DIFF
--- a/.monorepo.json
+++ b/.monorepo.json
@@ -45,6 +45,10 @@
       "version": "0.4.5",
       "hash": "37ed7e417435c92dbf301e7b26ea37ca"
     },
+    "devkit": {
+      "version": "0.4.5",
+      "hash": ""
+    },
     "@angular-devkit/architect": {
       "name": "Architect",
       "links": [

--- a/packages/_/devkit/collection.json
+++ b/packages/_/devkit/collection.json
@@ -1,0 +1,9 @@
+{
+  "schematics": {
+    "package": {
+      "factory": "./package/factory",
+      "schema": "./package/schema.json",
+      "description": "Create an empty schematic project or add a blank schematic to the current project."
+    }
+  }
+}

--- a/packages/_/devkit/package.json
+++ b/packages/_/devkit/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "devkit",
+  "version": "0.0.0",
+  "description": "Schematics specific to DevKit (used internally, not released)",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
+  "schematics": "./collection.json",
+  "private": true,
+  "peerDependencies": {
+    "@angular-devkit/core": "0.0.0",
+    "@angular-devkit/schematics": "0.0.0"
+  }
+}

--- a/packages/_/devkit/package/factory.ts
+++ b/packages/_/devkit/package/factory.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { JsonAstObject, JsonValue, parseJsonAst } from '@angular-devkit/core';
+import {
+  Rule,
+  SchematicContext,
+  Tree,
+  UpdateRecorder,
+  apply,
+  chain,
+  mergeWith,
+  template,
+  url,
+} from '@angular-devkit/schematics';
+import { Schema } from './schema';
+
+
+function appendPropertyInAstObject(
+  recorder: UpdateRecorder,
+  node: JsonAstObject,
+  propertyName: string,
+  value: JsonValue,
+  indent = 4,
+) {
+  const indentStr = '\n' + new Array(indent + 1).join(' ');
+
+  if (node.properties.length > 0) {
+    // Insert comma.
+    const last = node.properties[node.properties.length - 1];
+    recorder.insertRight(last.start.offset + last.text.replace(/\s+$/, '').length, ',');
+  }
+
+  recorder.insertLeft(
+    node.end.offset - 1,
+    '  '
+    + `"${propertyName}": ${JSON.stringify(value, null, 2).replace(/\n/g, indentStr)}`
+    + indentStr.slice(0, -2),
+  );
+}
+
+function addPackageToMonorepo(options: Schema, path: string): Rule {
+  return (tree: Tree) => {
+    const collectionJsonContent = tree.read('/.monorepo.json');
+    if (!collectionJsonContent) {
+      throw new Error('Could not find monorepo.json');
+    }
+    const collectionJsonAst = parseJsonAst(collectionJsonContent.toString('utf-8'));
+    if (collectionJsonAst.kind !== 'object') {
+      throw new Error('Invalid monorepo content.');
+    }
+
+    const packages = collectionJsonAst.properties.find(x => x.key.value == 'packages');
+    if (!packages) {
+      throw new Error('Cannot find packages key in monorepo.');
+    }
+    if (packages.value.kind != 'object') {
+      throw new Error('Invalid packages key.');
+    }
+
+    const readmeUrl = `https://github.com/angular/devkit/blob/master/${path}/README.md`;
+
+    const recorder = tree.beginUpdate('/.monorepo.json');
+    appendPropertyInAstObject(
+      recorder,
+      packages.value,
+      options.name,
+      {
+        name: options.displayName,
+        links: [{ label: 'README', url: readmeUrl }],
+        version: '0.0.1',
+        hash: '',
+      },
+    );
+    tree.commitUpdate(recorder);
+  };
+}
+
+
+export default function (options: Schema): Rule {
+  const path = 'packages/'
+    + options.name
+             .replace(/^@/, '')
+             .replace(/-/g, '_');
+
+  // Verify if we need to create a full project, or just add a new schematic.
+  return (tree: Tree, context: SchematicContext) => {
+    const source = apply(url('./project-files'), [
+      template({
+        ...options as object,
+        dot: '.',
+        path,
+      }),
+    ]);
+
+    return chain([
+      mergeWith(source),
+      addPackageToMonorepo(options, path),
+    ])(tree, context);
+  };
+}

--- a/packages/_/devkit/package/project-files/__path__/README.md
+++ b/packages/_/devkit/package/project-files/__path__/README.md
@@ -1,0 +1,3 @@
+# <%= displayName %>
+
+Work in progress

--- a/packages/_/devkit/package/project-files/__path__/package.json
+++ b/packages/_/devkit/package/project-files/__path__/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "<%= name %>",
+  "version": "0.0.0",
+  "description": "<%= description %>",
+  "main": "src/index.js",
+  "typings": "src/index.d.ts",
+  "scripts": {
+    "preinstall": "echo DO NOT INSTALL THIS PROJECT, ONLY THE ROOT PROJECT. && exit 1"
+  },
+  "keywords": [
+  ],
+  "license": "MIT",
+  "dependencies": {
+  },
+  "peerDependencies": {
+    "@angular-devkit/core": "0.0.0"
+  }
+}

--- a/packages/_/devkit/package/project-files/__path__/src/index.ts
+++ b/packages/_/devkit/package/project-files/__path__/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+// TODO: Make this useful (and awesome).
+export default 1;

--- a/packages/_/devkit/package/schema.d.ts
+++ b/packages/_/devkit/package/schema.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface Schema {
+    name: string;
+    description: string;
+    displayName: string;
+}

--- a/packages/_/devkit/package/schema.json
+++ b/packages/_/devkit/package/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsSchematicSchema",
+  "title": "DevKit Package Schematic Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The package name for the new schematic.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "description": {
+      "type": "string",
+      "description": "The description of the new package"
+    },
+    "displayName": {
+      "type": "string",
+      "$default": {
+        "$source": "interpolation",
+        "value": "${name}"
+      },
+      "description": "The human readable name."
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,7 @@
     "bazel-*/**/*",
     "dist/**/*",
     "node_modules/**/*",
+    "packages/_/devkit/**/*files/**/*",
     "packages/schematics/*/*/*files/**/*",
     "tmp/**/*",
     "scripts/patches/**/*",


### PR DESCRIPTION
Took me 15 minutes.

Add a new schematic package "devkit" (unpublished) that contains schematics
for the devkit.

To use, use something like:
  ```
  schematics devkit:package --name=my-test-package --description="Some Description" --displayName="test"
  ```