### PR TITLE
fix(@angular-devkit/build-webpack): use ngtools snapshot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -104,9 +104,7 @@
       "integrity": "sha1-w6DFRNYjkqzCgTpCyKDcb1j4aSI="
     },
     "@ngtools/webpack": {
-      "version": "6.0.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.0.0-beta.4.tgz",
-      "integrity": "sha512-K3JKyeZdicNHM0fhiftlBeXijbf6vD8S8SdlZ6XSyofGX8Dv4M8K2PnMhsxayD2X6Zw/m3mgd47tYr4VRMFGhw==",
+      "version": "github:angular/ngtools-webpack-builds#d05c6984d5f759e9ace4f8a779c2d22c2ddd60b1",
       "requires": {
         "chalk": "2.2.2",
         "semver": "5.4.1",
@@ -6592,9 +6590,9 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mini-css-extract-plugin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.1.0.tgz",
-      "integrity": "sha512-MRokS8rze/gAUQTU7f3jdRhVAFgYXhKb3Ziw/RnKC+jPxJBxqfn4QNt0GLq6yw+vOrsAG2c/jXxUZK1IG/z8Og==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.2.0.tgz",
+      "integrity": "sha512-rbuOYZCmNT0FW46hbhIKklBJ6ubwpcWnT81RmTsk0BLTQmL6euOH8lr2d7Wlv5ywJgpH3p7vKy5039dkn4YvxQ==",
       "requires": {
         "loader-utils": "1.1.0",
         "webpack-sources": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@angular/router": "^5.2.6",
     "@angular/service-worker": "^5.2.7",
     "@ngtools/json-schema": "^1.0.9",
-    "@ngtools/webpack": "6.0.0-beta.4",
+    "@ngtools/webpack": "github:angular/ngtools-webpack-builds#a0fc670",
     "@types/common-tags": "^1.4.0",
     "@types/copy-webpack-plugin": "^4.0.1",
     "@types/express": "^4.11.1",

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@angular-devkit/build-optimizer": "0.0.0",
-    "@ngtools/webpack": "6.0.0-beta.4",
+    "@ngtools/webpack": "github:angular/ngtools-webpack-builds#a0fc670",
     "autoprefixer": "^7.2.3",
     "cache-loader": "^1.2.2",
     "chalk": "~2.2.2",


### PR DESCRIPTION
It includes https://github.com/angular/angular-cli/pull/9969 which is needed to test APF v6.