### PR TITLE
ci: update webdriver manually

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   - npm install -g npm@~5.6.0
   - npm install
+  - npm run webdriver-update
 
 test_script:
   - node --version

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - checkout: *post_checkout
       - restore_cache: *_root_package_lock_key
+      - run: npm run webdriver-update
       - run: npm run test-large -- --code-coverage --full --spec-reporter
 
   integration:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6592,9 +6592,9 @@
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
     "mini-css-extract-plugin": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.1.0.tgz",
-      "integrity": "sha512-MRokS8rze/gAUQTU7f3jdRhVAFgYXhKb3Ziw/RnKC+jPxJBxqfn4QNt0GLq6yw+vOrsAG2c/jXxUZK1IG/z8Og==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.2.0.tgz",
+      "integrity": "sha512-rbuOYZCmNT0FW46hbhIKklBJ6ubwpcWnT81RmTsk0BLTQmL6euOH8lr2d7Wlv5ywJgpH3p7vKy5039dkn4YvxQ==",
       "requires": {
         "loader-utils": "1.1.0",
         "webpack-sources": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "integration:build-optimizer:simple": "cd tests/@angular_devkit/build_optimizer/webpack/simple-app && npm i -q --no-save && npm run e2e && npm run benchmark",
     "integration:build-optimizer:aio": "cd tests/@angular_devkit/build_optimizer/webpack/aio-app && npm i -q --no-save && npm run e2e && npm run benchmark",
     "postinstall": "npm run admin -- patch-dependencies",
-    "prepush": "node ./bin/devkit-admin hooks/pre-push"
+    "prepush": "node ./bin/devkit-admin hooks/pre-push",
+    "webdriver-update": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.33"
   },
   "repository": {
     "type": "git",

--- a/packages/angular_devkit/build_webpack/test/utils/default-workspaces.ts
+++ b/packages/angular_devkit/build_webpack/test/utils/default-workspaces.ts
@@ -118,6 +118,10 @@ export const protractorWorkspaceTarget: WorkspaceTarget<Partial<ProtractorBuilde
   options: {
     protractorConfig: '../protractor.conf.js',
     devServerTarget: 'app:devServer',
+    // Webdriver is updated with a specific version on devkit install.
+    // This is preferable to updating each time because it can download a new version of
+    // chromedriver that is incompatible with the Chrome version on CI.
+    webdriverUpdate: false,
   },
 };
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/package.json
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/package.json
@@ -9,7 +9,7 @@
     "serve": "lite-server",
     "pree2e": "npm run build -- --devtool=source-map",
     "e2e": "concurrently \"npm run serve\" \"npm run protractor\" --kill-others --success first",
-    "preprotractor": "webdriver-manager update",
+    "preprotractor": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.33",
     "protractor": "protractor protractor.config.js",
     "benchmark": "npm run build && npm run build-no-ngo && node benchmark.js",
     "reinstall-bo": "rimraf node_modules/@angular-devkit/build-optimizer && npm i -q ../../../../../dist/@angular-devkit_build-optimizer.tgz"

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/package.json
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/package.json
@@ -9,7 +9,7 @@
     "serve": "lite-server",
     "pree2e": "npm run build -- --devtool=source-map",
     "e2e": "concurrently \"npm run serve\" \"npm run protractor\" --kill-others --success first",
-    "preprotractor": "webdriver-manager update",
+    "preprotractor": "webdriver-manager update --standalone false --gecko false --versions.chrome 2.33",
     "protractor": "protractor protractor.config.js",
     "benchmark": "npm run build && npm run build-no-ngo && node benchmark.js",
     "reinstall-bo": "rimraf node_modules/@angular-devkit/build-optimizer && npm i -q ../../../../../dist/@angular-devkit_build-optimizer.tgz"


### PR DESCRIPTION
This is preferable to updating each time because it can download a new version of chromedriver that is incompatible with the Chrome version on CI.