### PR TITLE
feat(@angular-devkit/schematics): generate tree-shakeable services by default

### DIFF
--- a/packages/schematics/angular/service/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.service.ts
+++ b/packages/schematics/angular/service/files/__path__/__name@dasherize@if-flat__/__name@dasherize__.service.ts
@@ -1,8 +1,10 @@
-import { Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';<% if (providedIn) { %>
+import { <%= providedIn %> } from '<%= providedInPath %>';<% } %>
 
-@Injectable()
+@Injectable({
+  providedIn: <%= providedIn || "'root'" %>,
+})
 export class <%= classify(name) %>Service {
 
   constructor() { }
-
 }

--- a/packages/schematics/angular/service/index.ts
+++ b/packages/schematics/angular/service/index.ts
@@ -5,15 +5,13 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import { normalize, strings } from '@angular-devkit/core';
+import { Path, normalize, strings } from '@angular-devkit/core';
 import {
   Rule,
   SchematicContext,
   SchematicsException,
   Tree,
   apply,
-  branchAndMerge,
-  chain,
   filter,
   mergeWith,
   move,
@@ -22,61 +20,61 @@ import {
   url,
 } from '@angular-devkit/schematics';
 import * as ts from 'typescript';
-import { addProviderToModule } from '../utility/ast-utils';
-import { InsertChange } from '../utility/change';
+import { getFirstNgModuleName } from '../utility/ast-utils';
 import { buildRelativePath, findModuleFromOptions } from '../utility/find-module';
 import { Schema as ServiceOptions } from './schema';
 
+function getModuleNameFromPath(host: Tree, modulePath: Path) {
+  if (!host.exists(modulePath)) {
+    throw new SchematicsException(`File ${modulePath} does not exist.`);
+  }
 
-function addProviderToNgModule(options: ServiceOptions): Rule {
-  return (host: Tree) => {
-    if (!options.module) {
-      return host;
-    }
+  const text = host.read(modulePath);
+  if (text === null) {
+    throw new SchematicsException(`File ${modulePath} cannot be read.`);
+  }
+  const sourceText = text.toString('utf-8');
+  const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
 
-    const modulePath = options.module;
-    if (!host.exists(options.module)) {
-      throw new Error('Specified module does not exist');
-    }
+  return getFirstNgModuleName(source);
+}
 
-    const text = host.read(modulePath);
-    if (text === null) {
-      throw new SchematicsException(`File ${modulePath} does not exist.`);
-    }
-    const sourceText = text.toString('utf-8');
+function stripTsExtension(path: string): string {
+  if (!path.endsWith('.ts')) {
+    throw new SchematicsException(`File ${path} is not a Typescript file.`);
+  }
 
-    const source = ts.createSourceFile(modulePath, sourceText, ts.ScriptTarget.Latest, true);
-
-    const servicePath = `/${options.sourceDir}/${options.path}/`
-                        + (options.flat ? '' : strings.dasherize(options.name) + '/')
-                        + strings.dasherize(options.name)
-                        + '.service';
-    const relativePath = buildRelativePath(modulePath, servicePath);
-    const changes = addProviderToModule(source, modulePath,
-                                        strings.classify(`${options.name}Service`),
-                                        relativePath);
-    const recorder = host.beginUpdate(modulePath);
-    for (const change of changes) {
-      if (change instanceof InsertChange) {
-        recorder.insertLeft(change.pos, change.toAdd);
-      }
-    }
-    host.commitUpdate(recorder);
-
-    return host;
-  };
+  return path.substr(0, path.length - 3);
 }
 
 export default function (options: ServiceOptions): Rule {
   options.path = options.path ? normalize(options.path) : options.path;
   const sourceDir = options.sourceDir;
-  if (!sourceDir) {
+  if (sourceDir === undefined) {
     throw new SchematicsException(`sourceDir option is required.`);
   }
 
   return (host: Tree, context: SchematicContext) => {
+    let providedByModule = '';
+    let providedInPath = '';
+
     if (options.module) {
-      options.module = findModuleFromOptions(host, options);
+      const modulePath = findModuleFromOptions(host, options);
+      if (!modulePath || !host.exists(modulePath)) {
+        throw new Error('Specified module does not exist');
+      }
+      providedByModule = getModuleNameFromPath(host, modulePath) || '';
+
+      if (!providedByModule) {
+        throw new SchematicsException(`module option did not point to an @NgModule.`);
+      }
+
+      const servicePath = `/${options.sourceDir}/${options.path}/`
+        + (options.flat ? '' : strings.dasherize(options.name) + '/')
+        + strings.dasherize(options.name)
+        + '.service';
+
+      providedInPath = stripTsExtension(buildRelativePath(servicePath, modulePath));
     }
 
     const templateSource = apply(url('./files'), [
@@ -85,16 +83,12 @@ export default function (options: ServiceOptions): Rule {
         ...strings,
         'if-flat': (s: string) => options.flat ? '' : s,
         ...options,
+        providedIn: providedByModule,
+        providedInPath: providedInPath,
       }),
       move(sourceDir),
     ]);
 
-    return chain([
-      branchAndMerge(chain([
-        filter(path => path.endsWith('.module.ts') && !path.endsWith('-routing.module.ts')),
-        addProviderToNgModule(options),
-        mergeWith(templateSource),
-      ])),
-    ])(host, context);
+    return mergeWith(templateSource)(host, context);
   };
 }

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -8,11 +8,11 @@
 import { Tree, VirtualTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
-import { createAppModule, getFileContent } from '../utility/test';
+import { createAppModule } from '../utility/test';
 import { Schema as ServiceOptions } from './schema';
 
 
-describe('Pipe Schematic', () => {
+describe('Service Schematic', () => {
   const schematicRunner = new SchematicTestRunner(
     '@schematics/angular',
     path.join(__dirname, '../collection.json'),
@@ -42,20 +42,21 @@ describe('Pipe Schematic', () => {
     expect(files.indexOf('/src/app/foo/foo.service.ts')).toBeGreaterThanOrEqual(0);
   });
 
-  it('should not be provided by default', () => {
-    const options = { ...defaultOptions };
+  it('service should be tree-shakeable', () => {
+    const options = { ...defaultOptions};
 
     const tree = schematicRunner.runSchematic('service', options, appTree);
-    const content = getFileContent(tree, '/src/app/app.module.ts');
-    expect(content).not.toMatch(/import { FooService } from '.\/foo\/foo.service'/);
+    const content = tree.readContent('/src/app/foo/foo.service.ts');
+    expect(content).toMatch(/providedIn: 'root',/);
   });
 
-  it('should import into a specified module', () => {
+  it('should import a specified module', () => {
     const options = { ...defaultOptions, module: 'app.module.ts' };
 
     const tree = schematicRunner.runSchematic('service', options, appTree);
-    const content = getFileContent(tree, '/src/app/app.module.ts');
-    expect(content).toMatch(/import { FooService } from '.\/foo\/foo.service'/);
+    const content = tree.readContent('/src/app/foo/foo.service.ts');
+    expect(content).toMatch(/import { AppModule } from '..\/app.module'/);
+    expect(content).toMatch(/providedIn: AppModule,/);
   });
 
   it('should fail if specified module does not exist', () => {

--- a/packages/schematics/angular/utility/ast-utils.ts
+++ b/packages/schematics/angular/utility/ast-utils.ts
@@ -233,6 +233,38 @@ export function getDecoratorMetadata(source: ts.SourceFile, identifier: string,
     .map(expr => expr.arguments[0] as ts.ObjectLiteralExpression);
 }
 
+function findClassDeclarationParent(node: ts.Node): ts.ClassDeclaration|undefined {
+  if (ts.isClassDeclaration(node)) {
+    return node;
+  }
+
+  return node.parent && findClassDeclarationParent(node.parent);
+}
+
+/**
+ * Given a source file with @NgModule class(es), find the name of the first @NgModule class.
+ *
+ * @param source source file containing one or more @NgModule
+ * @returns the name of the first @NgModule, or `undefined` if none is found
+ */
+export function getFirstNgModuleName(source: ts.SourceFile): string|undefined {
+  // First, find the @NgModule decorators.
+  const ngModulesMetadata = getDecoratorMetadata(source, 'NgModule', '@angular/core');
+  if (ngModulesMetadata.length === 0) {
+    return undefined;
+  }
+
+  // Then walk parent pointers up the AST, looking for the ClassDeclaration parent of the NgModule
+  // metadata.
+  const moduleClass = findClassDeclarationParent(ngModulesMetadata[0]);
+  if (!moduleClass || !moduleClass.name) {
+    return undefined;
+  }
+
+  // Get the class name of the module ClassDeclaration.
+  return moduleClass.name.text;
+}
+
 export function addSymbolToNgModuleMetadata(
   source: ts.SourceFile,
   ngModulePath: string,


### PR DESCRIPTION
Change the 'service' schematic for Angular to generate a tree-shakeable
service by default. This greatly simplifies the schematic since it no longer
needs to add a provider to @NgModule.