### PR TITLE
List target names in Architect

### DIFF
--- a/packages/angular_devkit/architect/src/targets-schema.json
+++ b/packages/angular_devkit/architect/src/targets-schema.json
@@ -28,6 +28,7 @@
           }
         }
       },
+      "additionalProperties": false,
       "required": [
         "builder",
         "options"

--- a/packages/angular_devkit/architect_cli/bin/architect.ts
+++ b/packages/angular_devkit/architect_cli/bin/architect.ts
@@ -115,16 +115,14 @@ workspace.loadWorkspaceFromJson(workspaceJson).pipe(
       overrides,
     };
 
-    return architect.getBuilderConfiguration(targetSpec);
-  }),
-  concatMap(builderConfig => {
-
     // TODO: better logging of what's happening.
     if (argv.help) {
       // TODO: add target help
       return _throw('Target help NYI.');
       // architect.help(targetOptions, logger);
     } else {
+      const builderConfig = architect.getBuilderConfiguration(targetSpec);
+
       return architect.run(builderConfig, { logger });
     }
   }),

--- a/packages/angular_devkit/build_webpack/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_webpack/src/dev-server/index.ts
@@ -16,7 +16,7 @@ import { Path, getSystemPath, resolve, tags } from '@angular-devkit/core';
 import { existsSync, readFileSync } from 'fs';
 import * as path from 'path';
 import { Observable } from 'rxjs/Observable';
-import { concatMap, map, tap } from 'rxjs/operators';
+import { concatMap, map } from 'rxjs/operators';
 import * as url from 'url';
 import * as webpack from 'webpack';
 import { getWebpackStatsConfig } from '../angular-cli-files/models/webpack-configs/utils';
@@ -235,7 +235,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       headers: { 'Access-Control-Allow-Origin': '*' },
       historyApiFallback: {
         index: `${servePath}/${
-            path.relative(projectRoot, path.resolve(root, browserOptions.index))
+          path.relative(projectRoot, path.resolve(root, browserOptions.index))
           }`,
         disableDotRule: true,
         htmlAcceptHeaders: ['text/html', 'application/xhtml+xml'],
@@ -415,19 +415,18 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
   }
 
   private _getBrowserOptions(options: DevServerBuilderOptions) {
+    const architect = this.context.architect;
     const [project, target, configuration] = options.browserTarget.split(':');
     // Override browser build watch setting.
     const overrides = { watch: options.watch };
     const browserTargetSpec = { project, target, configuration, overrides };
-    let builderConfig: BuilderConfiguration<BrowserBuilderOptions>;
+    const builderConfig = architect.getBuilderConfiguration<BrowserBuilderOptions>(
+      browserTargetSpec);
 
-    return this.context.architect.getBuilderConfiguration<BrowserBuilderOptions>(browserTargetSpec)
-      .pipe(
-        tap(cfg => builderConfig = cfg),
-        concatMap(builderConfig => this.context.architect.getBuilderDescription(builderConfig)),
-        concatMap(browserDescription =>
-          this.context.architect.validateBuilderOptions(builderConfig, browserDescription)),
-        map(browserConfig => browserConfig.options),
+    return architect.getBuilderDescription(builderConfig).pipe(
+      concatMap(browserDescription =>
+        architect.validateBuilderOptions(builderConfig, browserDescription)),
+      map(browserConfig => browserConfig.options),
     );
   }
 }

--- a/packages/angular_devkit/build_webpack/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_webpack/src/extract-i18n/index.ts
@@ -15,7 +15,7 @@ import {
 import { resolve } from '@angular-devkit/core';
 import * as path from 'path';
 import { Observable } from 'rxjs/Observable';
-import { concatMap, map, tap } from 'rxjs/operators';
+import { concatMap, map } from 'rxjs/operators';
 import * as webpack from 'webpack';
 import { getWebpackStatsConfig } from '../angular-cli-files/models/webpack-configs/utils';
 import { statsErrorsToString, statsWarningsToString } from '../angular-cli-files/utilities/stats';
@@ -36,6 +36,7 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
   constructor(public context: BuilderContext) { }
 
   run(builderConfig: BuilderConfiguration<ExtractI18nBuilderOptions>): Observable<BuildEvent> {
+    const architect = this.context.architect;
     const options = builderConfig.options;
     const root = this.context.workspace.root;
     const projectRoot = resolve(root, builderConfig.root);
@@ -44,69 +45,68 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
     const overrides = { watch: false };
 
     const browserTargetSpec = { project, target: targetName, configuration, overrides };
-    let browserBuilderConfig: BuilderConfiguration<BrowserBuilderOptions>;
+    const browserBuilderConfig = architect.getBuilderConfiguration<BrowserBuilderOptions>(
+      browserTargetSpec);
 
-    return this.context.architect.getBuilderConfiguration<BrowserBuilderOptions>(browserTargetSpec)
-      .pipe(
-        tap(cfg => browserBuilderConfig = cfg),
-        concatMap(builderConfig => this.context.architect.getBuilderDescription(builderConfig)),
-        concatMap(browserDescription =>
-          this.context.architect.validateBuilderOptions(browserBuilderConfig, browserDescription)),
-        map(browserBuilderConfig => browserBuilderConfig.options),
-        concatMap((validatedBrowserOptions) => new Observable(obs => {
-          const browserOptions = validatedBrowserOptions;
-          const browserBuilder = new BrowserBuilder(this.context);
+    return architect.getBuilderDescription(browserBuilderConfig).pipe(
+      concatMap(browserDescription =>
+        architect.validateBuilderOptions(browserBuilderConfig, browserDescription)),
+      map(browserBuilderConfig => browserBuilderConfig.options),
+      concatMap((validatedBrowserOptions) => new Observable(obs => {
+        const browserOptions = validatedBrowserOptions;
+        const browserBuilder = new BrowserBuilder(this.context);
 
-          // We need to determine the outFile name so that AngularCompiler can retrieve it.
-          let outFile = options.outFile || getI18nOutfile(options.i18nFormat);
-          if (options.outputPath) {
-            // AngularCompilerPlugin doesn't support genDir so we have to adjust outFile instead.
-            outFile = path.join(options.outputPath, outFile);
+        // We need to determine the outFile name so that AngularCompiler can retrieve it.
+        let outFile = options.outFile || getI18nOutfile(options.i18nFormat);
+        if (options.outputPath) {
+          // AngularCompilerPlugin doesn't support genDir so we have to adjust outFile instead.
+          outFile = path.join(options.outputPath, outFile);
+        }
+
+        // Extracting i18n uses the browser target webpack config with some specific options.
+        const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, {
+          ...browserOptions,
+          optimizationLevel: 0,
+          i18nLocale: options.i18nLocale,
+          i18nOutFormat: options.i18nFormat,
+          i18nOutFile: outFile,
+          aot: true,
+        });
+
+        const webpackCompiler = webpack(webpackConfig);
+        webpackCompiler.outputFileSystem = new MemoryFS();
+        const statsConfig = getWebpackStatsConfig();
+
+        const callback: webpack.compiler.CompilerCallback = (err, stats) => {
+          if (err) {
+            return obs.error(err);
           }
 
-          // Extracting i18n uses the browser target webpack config with some specific options.
-          const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, {
-            ...browserOptions,
-            optimizationLevel: 0,
-            i18nLocale: options.i18nLocale,
-            i18nOutFormat: options.i18nFormat,
-            i18nOutFile: outFile,
-            aot: true,
-          });
-
-          const webpackCompiler = webpack(webpackConfig);
-          webpackCompiler.outputFileSystem = new MemoryFS();
-          const statsConfig = getWebpackStatsConfig();
-
-          const callback: webpack.compiler.CompilerCallback = (err, stats) => {
-            if (err) {
-              return obs.error(err);
-            }
-
-            const json = stats.toJson('verbose');
-            if (stats.hasWarnings()) {
-              this.context.logger.warn(statsWarningsToString(json, statsConfig));
-            }
-
-            if (stats.hasErrors()) {
-              this.context.logger.error(statsErrorsToString(json, statsConfig));
-            }
-
-            obs.next({ success: !stats.hasErrors() });
-
-            obs.complete();
-          };
-
-          try {
-            webpackCompiler.run(callback);
-          } catch (err) {
-            if (err) {
-              this.context.logger.error(
-                '\nAn error occured during the extraction:\n' + ((err && err.stack) || err));
-            }
-            throw err;
+          const json = stats.toJson('verbose');
+          if (stats.hasWarnings()) {
+            this.context.logger.warn(statsWarningsToString(json, statsConfig));
           }
-        })));
+
+          if (stats.hasErrors()) {
+            this.context.logger.error(statsErrorsToString(json, statsConfig));
+          }
+
+          obs.next({ success: !stats.hasErrors() });
+
+          obs.complete();
+        };
+
+        try {
+          webpackCompiler.run(callback);
+        } catch (err) {
+          if (err) {
+            this.context.logger.error(
+              '\nAn error occured during the extraction:\n' + ((err && err.stack) || err));
+          }
+          throw err;
+        }
+      })),
+    );
   }
 }
 

--- a/packages/angular_devkit/build_webpack/test/utils/run-target-spec.ts
+++ b/packages/angular_devkit/build_webpack/test/utils/run-target-spec.ts
@@ -9,7 +9,7 @@
 import { Architect, BuildEvent, TargetSpecifier } from '@angular-devkit/architect';
 import { experimental, join, logging, normalize } from '@angular-devkit/core';
 import { Observable } from 'rxjs/Observable';
-import { concatMap, tap } from 'rxjs/operators';
+import { concatMap } from 'rxjs/operators';
 import { TestProjectHost } from '../utils/test-project-host';
 
 
@@ -35,12 +35,9 @@ export function runTargetSpec(
 ): Observable<BuildEvent> {
   targetSpec = { ...targetSpec, overrides };
   const workspace = new experimental.workspace.Workspace(workspaceRoot, host);
-  let architect: Architect;
 
   return workspace.loadWorkspaceFromHost(workspaceFile).pipe(
     concatMap(ws => new Architect(ws).loadArchitect()),
-    tap(arch => architect = arch),
-    concatMap(() => architect.getBuilderConfiguration(targetSpec)),
-    concatMap(cfg => architect.run(cfg, { logger })),
+    concatMap(arch => arch.run(arch.getBuilderConfiguration(targetSpec), { logger })),
   );
 }


### PR DESCRIPTION
Listing project targets requires the target map to be loaded and validated when Architect is loaded.

This in turn simplifies the API by making `getBuilderConfiguration()` not need to return an observable.