### PR TITLE
fix(@angular-devkit/build-webpack): remove RxJS path mapping

### DIFF
--- a/packages/angular_devkit/build_webpack/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_webpack/src/angular-cli-files/models/webpack-configs/common.ts
@@ -6,7 +6,6 @@ import { HashedModuleIdsPlugin } from 'webpack';
 import * as CopyWebpackPlugin from 'copy-webpack-plugin';
 import { extraEntryParser, getOutputHashFormat, AssetPattern } from './utils';
 import { isDirectory } from '../../utilities/is-directory';
-import { requireProjectModule } from '../../utilities/require-project-module';
 import { WebpackConfigOptions } from '../build-options';
 import { BundleBudgetPlugin } from '../../plugins/bundle-budget';
 import { CleanCssWebpackPlugin } from '../../plugins/cleancss-webpack-plugin';
@@ -205,25 +204,13 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     loaderNodeModules.push(potentialNodeModules);
   }
 
-  // Load rxjs path aliases.
-  // https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md#build-and-treeshaking
-  let alias = {};
-  try {
-    const rxjsPathMappingImport = wco.supportES2015
-      ? 'rxjs/_esm2015/path-mapping'
-      : 'rxjs/_esm5/path-mapping';
-    const rxPaths = requireProjectModule(projectRoot, rxjsPathMappingImport);
-    alias = rxPaths(nodeModules);
-  } catch (e) { }
-
   return {
     mode: buildOptions.optimizationLevel === 0 ? 'development' : 'production',
     devtool: false,
     resolve: {
       extensions: ['.ts', '.js'],
       symlinks: !buildOptions.preserveSymlinks,
-      modules: [projectRoot, 'node_modules'],
-      alias
+      modules: [projectRoot, 'node_modules']
     },
     resolveLoader: {
       modules: loaderNodeModules


### PR DESCRIPTION
`rxjs@6.0.0-beta.0` added back the `module` and `es2015` keys in the `package.json` and the `path-mapping.js` is retained for backward compatibility only.