### PR TITLE
refactor(@angular-devkit/build-webpack): update circular dep plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1569,9 +1569,9 @@
       }
     },
     "circular-dependency-plugin": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-4.4.0.tgz",
-      "integrity": "sha512-yEFtUNUYT4jBykEX5ZOHw+5goA3glGZr9wAXIQqoyakjz5H5TeUmScnWRc52douAhb9eYzK3s7V6bXfNnjFdzg=="
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/circular-dependency-plugin/-/circular-dependency-plugin-5.0.0.tgz",
+      "integrity": "sha512-mJzk5D+Uy/bVVk89GDfdgINMc03FaqfpHg+nx/D8l2okD48FPmB5nBlpXj6HcmBkCv5AhY5qEfvCXmszc9vXpA=="
     },
     "class-utils": {
       "version": "0.3.6",
@@ -7256,6 +7256,29 @@
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
+        "less": {
+          "version": "2.7.3",
+          "resolved": "https://registry.npmjs.org/less/-/less-2.7.3.tgz",
+          "integrity": "sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==",
+          "requires": {
+            "errno": "0.1.4",
+            "graceful-fs": "4.1.11",
+            "image-size": "0.5.5",
+            "mime": "1.6.0",
+            "mkdirp": "0.5.1",
+            "promise": "7.3.1",
+            "request": "2.81.0",
+            "source-map": "0.5.7"
+          },
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+              "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+              "optional": true
+            }
+          }
+        },
         "load-json-file": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
@@ -7316,6 +7339,36 @@
           "requires": {
             "find-up": "2.1.0",
             "read-pkg": "3.0.0"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.17",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.1.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.1.0"
           }
         },
         "rimraf": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "cache-loader": "^1.2.2",
     "chalk": "~2.2.2",
     "chokidar": "^1.7.0",
-    "circular-dependency-plugin": "^4.4.0",
+    "circular-dependency-plugin": "^5.0.0",
     "clean-css": "^4.1.11",
     "codelyzer": "^4.0.2",
     "common-tags": "^1.5.1",

--- a/packages/angular_devkit/build_webpack/package.json
+++ b/packages/angular_devkit/build_webpack/package.json
@@ -14,7 +14,7 @@
     "autoprefixer": "^7.2.3",
     "cache-loader": "^1.2.2",
     "chalk": "~2.2.2",
-    "circular-dependency-plugin": "^4.4.0",
+    "circular-dependency-plugin": "^5.0.0",
     "clean-css": "^4.1.11",
     "common-tags": "^1.5.1",
     "copy-webpack-plugin": "^4.5.0",


### PR DESCRIPTION
Removes a deprecation warning message during builds.