### PR TITLE
Declare expected external typings

### DIFF
--- a/packages/angular_devkit/core/BUILD
+++ b/packages/angular_devkit/core/BUILD
@@ -22,6 +22,11 @@ ts_library(
     module_root = "src",
     deps = [
         # @deps: rxjs
+        # @typings: es2015.core
+        # @typings: es2015.symbol.wellknown
+        # @typings: ajv
+        # @typings: node
+        # @typings: source-map
     ],
 )
 


### PR DESCRIPTION
Add hints of external typings required so they can be substituted by the relevant paths in context where they need to be explicit (e.g. google3).