### PR TITLE
fix(@angular-devkit/build-angular): default bundleName logic

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -1,6 +1,7 @@
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 
+import { basename, normalize } from '@angular-devkit/core';
 import * as path from 'path';
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const SubresourceIntegrityPlugin = require('webpack-subresource-integrity');
@@ -27,7 +28,15 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   // Figure out which are the lazy loaded bundle names.
   const lazyChunkBundleNames = ([...buildOptions.styles, ...buildOptions.scripts] as ExtraEntryPoint[])
     .filter(entry => entry.lazy)
-    .map(entry => entry.bundleName);
+    .map(entry => {
+      if (!entry.bundleName) {
+        return basename(
+          normalize(entry.input.replace(/\.(js|css|scss|sass|less|styl)$/i, '')),
+        );
+      } else {
+        return entry.bundleName;
+      }
+    });
 
   const generateIndexHtml = false;
   if (generateIndexHtml) {
@@ -76,7 +85,17 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
   }
 
   const globalStylesBundleNames = (buildOptions.styles as ExtraEntryPoint[])
-    .map(style => style.bundleName);
+    .map(style => {
+      if (style.bundleName) {
+        return style.bundleName;
+      } else if (style.lazy) {
+        return basename(
+          normalize(style.input.replace(/\.(js|css|scss|sass|less|styl)$/i, '')),
+        );
+      } else {
+        return 'styles';
+      }
+    });
 
   return {
     devtool: sourcemaps,

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -1,6 +1,7 @@
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 
+import { basename, normalize } from '@angular-devkit/core';
 import * as webpack from 'webpack';
 import * as path from 'path';
 import { SuppressExtractedTextChunksWebpackPlugin } from '../../plugins/webpack';
@@ -168,14 +169,25 @@ export function getStylesConfig(wco: WebpackConfigOptions) {
   // Process global styles.
   if (buildOptions.styles.length > 0) {
     (buildOptions.styles as ExtraEntryPoint[]).forEach(style => {
+      let bundleName = style.bundleName;
+      if (!bundleName) {
+        if (style.lazy) {
+          bundleName = basename(
+            normalize(style.input.replace(/\.(js|css|scss|sass|less|styl)$/i, '')),
+          );
+        }
+        else {
+          bundleName = 'styles';
+        }
+      }
 
       const resolvedPath = path.resolve(root, style.input);
 
       // Add style entry points.
-      if (entryPoints[style.bundleName]) {
-        entryPoints[style.bundleName].push(resolvedPath)
+      if (entryPoints[bundleName]) {
+        entryPoints[bundleName].push(resolvedPath)
       } else {
-        entryPoints[style.bundleName] = [resolvedPath]
+        entryPoints[bundleName] = [resolvedPath]
       }
 
       // Add global css paths.

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
@@ -7,14 +7,18 @@ export function generateEntryPoints(appConfig: any) {
   let entryPoints = ['polyfills', 'sw-register'];
 
   // Add all styles/scripts, except lazy-loaded ones.
-  const lazyChunkBundleNames = ([...appConfig.styles, ...appConfig.scripts] as ExtraEntryPoint[])
-    .filter(entry => !entry.lazy)
-    .map(entry => entry.bundleName)
-    .forEach(bundleName => {
-      if (entryPoints.indexOf(bundleName) === -1) {
-        entryPoints.push(bundleName);
-      }
-    });
+  [
+    ...(appConfig.styles as ExtraEntryPoint[])
+      .filter(entry => !entry.lazy)
+      .map(entry => entry.bundleName || 'styles'),
+    ...(appConfig.scripts as ExtraEntryPoint[])
+      .filter(entry => !entry.lazy)
+      .map(entry => entry.bundleName || 'scripts'),
+  ].forEach(bundleName => {
+    if (entryPoints.indexOf(bundleName) === -1) {
+      entryPoints.push(bundleName);
+    }
+  });
 
   entryPoints.push('main');
 

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -278,8 +278,7 @@
         },
         "bundleName": {
           "type": "string",
-          "description": "The bundle name for this extra entry point.",
-          "default": "styles"
+          "description": "The bundle name for this extra entry point."
         },
         "lazy": {
           "type": "boolean",
@@ -301,8 +300,7 @@
         },
         "bundleName": {
           "type": "string",
-          "description": "The bundle name for this extra entry point.",
-          "default": "scripts"
+          "description": "The bundle name for this extra entry point. Default is the basename of the input."
         },
         "lazy": {
           "type": "boolean",


### PR DESCRIPTION
If lazy, basename of input. If not lazy, just "styles" or "scripts".