### PR TITLE
fix(@angular/pwa): typo and display standalone in manifest.json

### DIFF
--- a/packages/angular/pwa/pwa/files/assets/manifest.json
+++ b/packages/angular/pwa/pwa/files/assets/manifest.json
@@ -3,8 +3,8 @@
   "short_name": "<%= title %>",
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
-  "display": "browser",
-  "Scope": "/",
+  "display": "standalone",
+  "scope": "/",
   "start_url": "/",
   "icons": [
     {


### PR DESCRIPTION
In `manifest.json`: 
- fixes a typo in `scope` property
- changes `display` to `standalone` instead of `browser` (otherwise it's just a normal website, not a PWA)

I'm also concerned about the manifest being in `assets`, as the default `ngsw-config.json` tells to lazy load `assets`, while the `manifest.json` should certainly be prefetched (but as it should be load from start by the browser, maybe it's OK).

@filipesilva 