### PR TITLE
fix(@schematics/angular): default to non prod builds on new application

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build --prod",
+    "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
The current behaviour is risky if the user does not realize he is using a prod
environment. It could have potential disastrous effects.

By contrast, if the user build a dev build by default, it is trivial for her to
change the package.json to her liking.

This PR reduces the risk while inducing minimal pain on most people.

Fix https://github.com/angular/angular-cli/issues/10191