### PR TITLE
fix(@schematics/angular): Correct paths for linting libraries

### DIFF
--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -147,11 +147,11 @@ function addAppToWorkspaceFile(options: LibraryOptions, workspace: WorkspaceSche
           },
         },
         lint: {
-          builder: '@angular-devkit/build-angular:lint',
+          builder: '@angular-devkit/build-angular:tslint',
           options: {
             tsConfig: [
-              'projects/lib/tsconfig.lint.json',
-              'projects/lib/tsconfig.spec.json',
+              `${projectRoot}/tsconfig.lint.json`,
+              `${projectRoot}/tsconfig.spec.json`,
             ],
             exclude: [
               '**/node_modules/**',


### PR DESCRIPTION
When creating a new library, the paths for lint were false.

Now the correct paths should be set.

CC @filipesilva 