### PR TITLE
feat(@schematics/angular): Add directive and component selector rules

### DIFF
--- a/packages/schematics/angular/application/files/lint/__tsLintRoot__/tslint.json
+++ b/packages/schematics/angular/application/files/lint/__tsLintRoot__/tslint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "<%= relativeTsLintPath %>/tslint.json",
+    "rules": {
+        "directive-selector": [
+            true,
+            "attribute",
+            "<%= prefix %>",
+            "camelCase"
+        ],
+        "component-selector": [
+            true,
+            "element",
+            "<%= prefix %>",
+            "kebab-case"
+        ]
+    }
+}

--- a/packages/schematics/angular/application/index_spec.ts
+++ b/packages/schematics/angular/application/index_spec.ts
@@ -47,6 +47,7 @@ describe('Application Schematic', () => {
     expect(files.indexOf('/projects/foo/karma.conf.js')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/tsconfig.app.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/tsconfig.spec.json')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/projects/foo/tslint.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/environments/environment.ts')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/environments/environment.prod.ts')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/favicon.ico')).toBeGreaterThanOrEqual(0);
@@ -109,6 +110,15 @@ describe('Application Schematic', () => {
     expect(specTsConfig.files).toEqual(['src/test.ts', 'src/polyfills.ts']);
   });
 
+  it('should set the right path and prefix in the tslint file', () => {
+    const tree = schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
+    const path = '/projects/foo/tslint.json';
+    const content = JSON.parse(tree.readContent(path));
+    expect(content.extends).toMatch('../../tslint.json');
+    expect(content.rules['directive-selector'][2]).toMatch('app');
+    expect(content.rules['component-selector'][2]).toMatch('app');
+  });
+
   describe(`update package.json`, () => {
     it(`should add build-angular to devDependencies`, () => {
       const tree = schematicRunner.runSchematic('application', defaultOptions, workspaceTree);
@@ -157,6 +167,7 @@ describe('Application Schematic', () => {
       expect(files.indexOf('/src/karma.conf.js')).toBeGreaterThanOrEqual(0);
       expect(files.indexOf('/src/tsconfig.app.json')).toBeGreaterThanOrEqual(0);
       expect(files.indexOf('/src/tsconfig.spec.json')).toBeGreaterThanOrEqual(0);
+      expect(files.indexOf('/src/tslint.json')).toBeGreaterThanOrEqual(0);
       expect(files.indexOf('/src/environments/environment.ts')).toBeGreaterThanOrEqual(0);
       expect(files.indexOf('/src/environments/environment.prod.ts')).toBeGreaterThanOrEqual(0);
       expect(files.indexOf('/src/favicon.ico')).toBeGreaterThanOrEqual(0);
@@ -195,6 +206,16 @@ describe('Application Schematic', () => {
       const specTsConfig = JSON.parse(tree.readContent('/src/tsconfig.spec.json'));
       expect(specTsConfig.extends).toEqual('../tsconfig.json');
       expect(specTsConfig.files).toEqual(['test.ts', 'polyfills.ts']);
+    });
+
+    it('should set the relative path and prefix in the tslint file', () => {
+      const options = { ...defaultOptions, projectRoot: '' };
+
+      const tree = schematicRunner.runSchematic('application', options, workspaceTree);
+      const content = JSON.parse(tree.readContent('/src/tslint.json'));
+      expect(content.extends).toMatch('../tslint.json');
+      expect(content.rules['directive-selector'][2]).toMatch('app');
+      expect(content.rules['component-selector'][2]).toMatch('app');
     });
   });
 });

--- a/packages/schematics/angular/library/files/__projectRoot__/tslint.json
+++ b/packages/schematics/angular/library/files/__projectRoot__/tslint.json
@@ -1,0 +1,17 @@
+{
+    "extends": "<%= relativeTsLintPath %>/tslint.json",
+    "rules": {
+        "directive-selector": [
+            true,
+            "attribute",
+            "<%= prefix %>",
+            "camelCase"
+        ],
+        "component-selector": [
+            true,
+            "element",
+            "<%= prefix %>",
+            "kebab-case"
+        ]
+    }
+}

--- a/packages/schematics/angular/library/index.ts
+++ b/packages/schematics/angular/library/index.ts
@@ -172,17 +172,21 @@ export default function (options: LibraryOptions): Rule {
       throw new SchematicsException(`Invalid options, "name" is required.`);
     }
     const name = options.name;
+    const prefix = options.prefix || 'lib';
 
     const workspace = getWorkspace(host);
     const newProjectRoot = workspace.newProjectRoot;
     const projectRoot = `${newProjectRoot}/${options.name}`;
     const sourceDir = `${projectRoot}/src/lib`;
+    const relativeTsLintPath = projectRoot.split('/').map(x => '..').join('/');
 
     const templateSource = apply(url('./files'), [
       template({
         ...strings,
         ...options,
         projectRoot,
+        relativeTsLintPath,
+        prefix,
       }),
       // TODO: Moving inside `branchAndMerge` should work but is bugged right now.
       // The __projectRoot__ is being used meanwhile.
@@ -203,6 +207,7 @@ export default function (options: LibraryOptions): Rule {
       }),
       schematic('component', {
         name: name,
+        selector: `${prefix}-${name}`,
         inlineStyle: true,
         inlineTemplate: true,
         flat: true,

--- a/packages/schematics/angular/library/index_spec.ts
+++ b/packages/schematics/angular/library/index_spec.ts
@@ -44,6 +44,7 @@ describe('Library Schematic', () => {
     expect(files.indexOf('/projects/foo/karma.conf.js')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/ng-package.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/package.json')).toBeGreaterThanOrEqual(0);
+    expect(files.indexOf('/projects/foo/tslint.json')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/test.ts')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/my_index.ts')).toBeGreaterThanOrEqual(0);
     expect(files.indexOf('/projects/foo/src/lib/foo.module.ts')).toBeGreaterThanOrEqual(0);
@@ -86,6 +87,15 @@ describe('Library Schematic', () => {
     const tree = schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
     const fileContent = getFileContent(tree, '/projects/foo/src/lib/foo.module.ts');
     expect(fileContent).toContain('exports: [FooComponent]');
+  });
+
+  it('should set the right path and prefix in the tslint file', () => {
+    const tree = schematicRunner.runSchematic('library', defaultOptions, workspaceTree);
+    const path = '/projects/foo/tslint.json';
+    const content = JSON.parse(tree.readContent(path));
+    expect(content.extends).toMatch('../../tslint.json');
+    expect(content.rules['directive-selector'][2]).toMatch('lib');
+    expect(content.rules['component-selector'][2]).toMatch('lib');
   });
 
   describe(`update package.json`, () => {

--- a/packages/schematics/angular/library/schema.d.ts
+++ b/packages/schematics/angular/library/schema.d.ts
@@ -16,6 +16,10 @@ export interface Schema {
    */
   entryFile: string;
   /**
+   * The prefix to apply to generated selectors.
+   */
+  prefix?: string;
+  /**
    * Do not add dependencies to package.json (e.g., --skipPackageJson)
    */
   skipPackageJson: boolean;

--- a/packages/schematics/angular/library/schema.json
+++ b/packages/schematics/angular/library/schema.json
@@ -18,6 +18,13 @@
       "description": "The path to create the library's public API file.",
       "default": "public_api"
     },
+    "prefix": {
+      "type": "string",
+      "format": "html-selector",
+      "description": "The prefix to apply to generated selectors.",
+      "default": "lib",
+      "alias": "p"
+    },
     "skipPackageJson": {
       "type": "boolean",
       "default": false,


### PR DESCRIPTION
Here is the initial implementation and fix of https://github.com/angular/devkit/issues/570

Some questions:
1. When i add the `schematics/angular/application/files/root/tslint.json`, the workspace tslint file is not copied when i run `ng new App`, only the extending tslint exists in the created application. Is it not possible to create two files with the same name in different directories or am i missing something?
1. The LibraryOptions don't have a property for prefix, so i just chose `lib` for now. Should i add a prefix property and use it?
1. Should i add tests somewhere?

CC @filipesilva 