### PR TITLE
fix(@angular-devkit/build-angular): always use absolute path for loader

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -14,9 +14,7 @@ const SilentError = require('silent-error');
 
 
 const g: any = typeof global !== 'undefined' ? global : {};
-const webpackLoader: string = g['_DevKitIsLocal']
-  ? require.resolve('@ngtools/webpack')
-  : '@ngtools/webpack';
+const webpackLoader: string = require.resolve('@ngtools/webpack');
 
 
 function _createAotPlugin(


### PR DESCRIPTION
Otherwise webpack tries to resolve it and when using yarn will not be able
to find it.

Fix https://github.com/angular/angular-cli/issues/10220