### PR TITLE
fix(@schematics/angular): remove extra comma in service

### DIFF
--- a/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.ts
+++ b/packages/schematics/angular/service/files/__name@dasherize@if-flat__/__name@dasherize__.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';<% if (providedIn) { %>
 import { <%= providedIn %> } from '<%= providedInPath %>';<% } %>
 
 @Injectable({
-  providedIn: <%= providedIn || "'root'" %>,
+  providedIn: <%= providedIn || "'root'" %>
 })
 export class <%= classify(name) %>Service {
 

--- a/packages/schematics/angular/service/index_spec.ts
+++ b/packages/schematics/angular/service/index_spec.ts
@@ -59,7 +59,7 @@ describe('Service Schematic', () => {
 
     const tree = schematicRunner.runSchematic('service', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.service.ts');
-    expect(content).toMatch(/providedIn: 'root',/);
+    expect(content).toMatch(/providedIn: 'root'/);
   });
 
   it('should import a specified module', () => {
@@ -68,7 +68,7 @@ describe('Service Schematic', () => {
     const tree = schematicRunner.runSchematic('service', options, appTree);
     const content = tree.readContent('/projects/bar/src/app/foo/foo.service.ts');
     expect(content).toMatch(/import { AppModule } from '..\/app.module'/);
-    expect(content).toMatch(/providedIn: AppModule,/);
+    expect(content).toMatch(/providedIn: AppModule/);
   });
 
   it('should fail if specified module does not exist', () => {


### PR DESCRIPTION
Other schematics don't have extra comma: this commit aligns the service schematics with the others.