### PR TITLE
fix(@angular-devkit/schematics): QoL changes for run-schematic

### DIFF
--- a/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/executor.ts
@@ -9,18 +9,21 @@ import { SchematicContext, TaskExecutor } from '../../src';
 import { RunSchematicTaskOptions } from './options';
 
 
-export default function(): TaskExecutor<RunSchematicTaskOptions> {
-  return (options: RunSchematicTaskOptions, context: SchematicContext) => {
+export default function(): TaskExecutor<RunSchematicTaskOptions<{}>> {
+  return (options: RunSchematicTaskOptions<{}>, context: SchematicContext) => {
     const maybeWorkflow = context.engine.workflow;
+    const collection = options.collection || context.schematic.collection.description.name;
 
     if (!maybeWorkflow) {
       throw new Error('Need Workflow to support executing schematics as post tasks.');
     }
 
     return maybeWorkflow.execute({
-      collection: options.collection,
+      collection: collection,
       schematic: options.name,
       options: options.options,
+      // Allow private when calling from the same collection.
+      allowPrivate: collection == context.schematic.collection.description.name,
     });
   };
 }

--- a/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/options.ts
@@ -7,8 +7,8 @@
  */
 export const RunSchematicName = 'run-schematic';
 
-export interface RunSchematicTaskOptions {
-  collection: string;
+export interface RunSchematicTaskOptions<T> {
+  collection: string | null;
   name: string;
-  options: object;
+  options: T;
 }

--- a/packages/angular_devkit/schematics/tasks/run-schematic/task.ts
+++ b/packages/angular_devkit/schematics/tasks/run-schematic/task.ts
@@ -9,14 +9,27 @@ import { TaskConfiguration, TaskConfigurationGenerator } from '../../src';
 import { RunSchematicName, RunSchematicTaskOptions } from './options';
 
 
-export class RunSchematicTask implements TaskConfigurationGenerator<RunSchematicTaskOptions> {
-  constructor(
-    protected _collection: string,
-    protected _schematic: string,
-    protected _options: object,
-  ) {}
+export class RunSchematicTask<T> implements TaskConfigurationGenerator<RunSchematicTaskOptions<T>> {
+  protected _collection: string | null;
+  protected _schematic: string;
+  protected _options: T;
 
-  toConfiguration(): TaskConfiguration<RunSchematicTaskOptions> {
+  constructor(s: string, o: T);
+  constructor(c: string, s: string, o: T);
+
+  constructor(c: string | null, s: string | T, o?: T) {
+    if (arguments.length == 2 || typeof s !== 'string') {
+      o = s as T;
+      s = c as string;
+      c = null;
+    }
+
+    this._collection = c;
+    this._schematic = s as string;
+    this._options = o as T;
+  }
+
+  toConfiguration(): TaskConfiguration<RunSchematicTaskOptions<T>> {
     return {
       name: RunSchematicName,
       options: {


### PR DESCRIPTION
Allow private schematics to run on the RunSchematic task. Also allow 2 arguments
to the constructor which will call a schematic from the same collection.