### PR TITLE
fix(@angular-devkit/build-angular): add newline on rebuilds

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -47,13 +47,13 @@ export function statsToString(json: any, statsConfig: any) {
   const unchangedChunkNumber = json.chunks.length - changedChunksStats.length;
 
   if (unchangedChunkNumber > 0) {
-    return rs(tags.stripIndents`
+    return '\n' + rs(tags.stripIndents`
       Date: ${w(new Date().toISOString())} - Hash: ${w(json.hash)} - Time: ${w('' + json.time)}ms
       ${unchangedChunkNumber} unchanged chunks
       ${changedChunksStats.join('\n')}
       `);
   } else {
-    return rs(tags.stripIndents`
+    return '\n' + rs(tags.stripIndents`
       Date: ${w(new Date().toISOString())}
       Hash: ${w(json.hash)}
       Time: ${w('' + json.time)}ms


### PR DESCRIPTION
Before
```
Date: 2018-04-10T14:39:58.064Z
Hash: 9819722f17ec7c60f5bf
Time: 5642ms
chunk {main} main.js, main.js.map (main) 9.11 kB [initial] [rendered]
chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 231 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 5.09 kB [entry] [rendered]
chunk {styles} styles.js, styles.js.map (styles) 16.5 kB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.11 MB [initial] [rendered]
Date: 2018-04-10T14:40:02.821Z - Hash: 7d97903e4271af730b4f - Time: 3539ms
2 unchanged chunks
chunk {lazy-lazy-module} lazy-lazy-module.js, lazy-lazy-module.js.map (lazy-lazy-module) 4.08 kB  [rendered]
chunk {main} main.js, main.js.map (main) 9.84 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 7.73 kB [entry] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.47 MB [initial] [rendered]
Date: 2018-04-10T14:40:06.177Z - Hash: ac12b06f6cea2135c2cd - Time: 2146ms
3 unchanged chunks
chunk {lazy-lazy-module} lazy-lazy-module.js, lazy-lazy-module.js.map (lazy-lazy-module) 259 kB  [rendered]
chunk {main} main.js, main.js.map (main) 9.45 kB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.11 MB [initial] [rendered]
```

After
```
Date: 2018-04-10T14:40:56.977Z
Hash: 9819722f17ec7c60f5bf
Time: 5633ms
chunk {main} main.js, main.js.map (main) 9.11 kB [initial] [rendered]
chunk {polyfills} polyfills.js, polyfills.js.map (polyfills) 231 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 5.09 kB [entry] [rendered]
chunk {styles} styles.js, styles.js.map (styles) 16.5 kB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.11 MB [initial] [rendered]

Date: 2018-04-10T14:41:01.208Z - Hash: 7d97903e4271af730b4f - Time: 3015ms
2 unchanged chunks
chunk {lazy-lazy-module} lazy-lazy-module.js, lazy-lazy-module.js.map (lazy-lazy-module) 4.08 kB  [rendered]
chunk {main} main.js, main.js.map (main) 9.84 kB [initial] [rendered]
chunk {runtime} runtime.js, runtime.js.map (runtime) 7.73 kB [entry] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.47 MB [initial] [rendered]

Date: 2018-04-10T14:41:04.556Z - Hash: ac12b06f6cea2135c2cd - Time: 2139ms
3 unchanged chunks
chunk {lazy-lazy-module} lazy-lazy-module.js, lazy-lazy-module.js.map (lazy-lazy-module) 259 kB  [rendered]
chunk {main} main.js, main.js.map (main) 9.45 kB [initial] [rendered]
chunk {vendor} vendor.js, vendor.js.map (vendor) 3.11 MB [initial] [rendered]
```