### PR TITLE
fix(@angular-devkit/build-angular): adjust chunk splitting options

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -95,11 +95,13 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
       runtimeChunk: 'single',
       splitChunks: {
         chunks: buildOptions.commonChunk ? 'all' : 'initial',
+        maxAsyncRequests: Infinity,
         cacheGroups: {
           vendors: false,
           vendor: buildOptions.vendorChunk && {
             name: 'vendor',
             chunks: 'initial',
+            enforce: true,
             test: (module: any, chunks: Array<{ name: string }>) => {
               const moduleName = module.nameForCondition ? module.nameForCondition() : '';
               return /[\\/]node_modules[\\/]/.test(moduleName)


### PR DESCRIPTION
This ensures that initial vendor modules are alway placed in the vendor bundle.  And also increases the potential for splitting common modules out of async (lazy route) chunks.

Mitigates angular/angular-cli#10294