### PR TITLE
fix(@angular-devkit/build-optimizer): remove side effects override

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -251,10 +251,10 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           }
         },
         {
-          test: /[\/\\]@angular[\/\\].+\.js$/,
-          sideEffects: false,
+          // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
+          // Removing this will cause deprecation warnings to appear.
+          test: /[\/\\]@angular[\/\\]core[\/\\].+\.js$/,
           parser: { system: true },
-          ...buildOptimizerUseRule,
         },
         {
           test: /\.js$/,


### PR DESCRIPTION
Also prevent Build Optimizer from running twice on Angular packages.

Partially address https://github.com/angular/angular-cli/issues/10322.