### PR TITLE
fix(@schematics/angular): build in --prod mode by default

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "start": "ng serve",
-    "build": "ng build",
+    "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Reintroduce #221, which has (also) disappeared from new schematics...

Would be really nice to include this before final v6. :)

@filipesilva @hansl @Brocco @StephenFluin 