### PR TITLE
feat(@schematics/angular): new npm script for prod build

### DIFF
--- a/packages/schematics/angular/workspace/files/package.json
+++ b/packages/schematics/angular/workspace/files/package.json
@@ -6,6 +6,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
+    "prod": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e"


### PR DESCRIPTION
Follow up of #221 and angular/angular-cli#10191, with a solution for both problems:
- let the default `build` script in dev mode to avoid hitting production APIs by mistake,
- add a new `prod` script so beginners know and see explicitly there is a special option to activate when going to production.

@hansl @Brocco @filipesilva 