### PR TITLE
feat(@schematics/angular): strict option

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -40,6 +40,7 @@ export default function (options: NgNewOptions): Rule {
     name: options.name,
     version: options.version,
     newProjectRoot: options.newProjectRoot || 'projects',
+    strict: options.strict,
   };
   const applicationOptions: ApplicationOptions = {
     projectRoot: '',

--- a/packages/schematics/angular/ng-new/index_spec.ts
+++ b/packages/schematics/angular/ng-new/index_spec.ts
@@ -46,4 +46,16 @@ describe('Ng New Schematic', () => {
     const content = tree.readContent('/bar/angular.json');
     expect(content).toMatch(/"prefix": "pre"/);
   });
+
+  it('should set strict options in tsconfig.json', () => {
+    const options = { ...defaultOptions, strict: true };
+    const tree = schematicRunner.runSchematic('ng-new', options);
+    const tsconfig = JSON.parse(tree.readContent('/bar/tsconfig.json'));
+
+    expect(tsconfig.compilerOptions.noImplicitAny).toBe(true);
+    expect(tsconfig.compilerOptions.strictNullChecks).toBe(true);
+    expect(tsconfig.compilerOptions.noImplicitThis).toBe(true);
+    expect(tsconfig.compilerOptions.alwaysStrict).toBe(true);
+    expect(tsconfig.compilerOptions.strictFunctionTypes).toBe(true);
+  });
 });

--- a/packages/schematics/angular/ng-new/schema.d.ts
+++ b/packages/schematics/angular/ng-new/schema.d.ts
@@ -67,4 +67,8 @@ export interface Schema {
    * Skip creating spec files.
    */
   skipTests?: boolean;
+  /**
+   * Configure TypeScript in strict mode.
+   */
+  strict?: boolean;
 }

--- a/packages/schematics/angular/ng-new/schema.json
+++ b/packages/schematics/angular/ng-new/schema.json
@@ -111,6 +111,11 @@
       "type": "boolean",
       "default": false,
       "alias": "S"
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Configure TypeScript in strict mode.",
+      "default": false
     }
   },
   "required": [

--- a/packages/schematics/angular/workspace/files/tsconfig.json
+++ b/packages/schematics/angular/workspace/files/tsconfig.json
@@ -15,6 +15,11 @@
     "lib": [
       "es2017",
       "dom"
-    ]
+    ]<% if (strict) { %>,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "strictFunctionTypes": true<% } %>
   }
 }

--- a/packages/schematics/angular/workspace/index_spec.ts
+++ b/packages/schematics/angular/workspace/index_spec.ts
@@ -55,4 +55,16 @@ describe('Workspace Schematic', () => {
     expect(pkg.dependencies['zone.js']).toEqual(latestVersions.ZoneJs);
     expect(pkg.devDependencies['typescript']).toEqual(latestVersions.TypeScript);
   });
+
+  it('should set strict options in tsconfig.json', () => {
+    const options = { ...defaultOptions, strict: true };
+    const tree = schematicRunner.runSchematic('workspace', options);
+    const tsconfig = JSON.parse(tree.readContent('/tsconfig.json'));
+
+    expect(tsconfig.compilerOptions.noImplicitAny).toBe(true);
+    expect(tsconfig.compilerOptions.strictNullChecks).toBe(true);
+    expect(tsconfig.compilerOptions.noImplicitThis).toBe(true);
+    expect(tsconfig.compilerOptions.alwaysStrict).toBe(true);
+    expect(tsconfig.compilerOptions.strictFunctionTypes).toBe(true);
+  });
 });

--- a/packages/schematics/angular/workspace/schema.d.ts
+++ b/packages/schematics/angular/workspace/schema.d.ts
@@ -35,4 +35,8 @@ export interface Schema {
      * The version of the Angular CLI to use.
      */
     version?: string;
+    /**
+     * Configure TypeScript in strict mode.
+     */
+    strict?: boolean;
 }

--- a/packages/schematics/angular/workspace/schema.json
+++ b/packages/schematics/angular/workspace/schema.json
@@ -65,6 +65,11 @@
       "type": "string",
       "description": "The version of the Angular CLI to use.",
       "visible": false
+    },
+    "strict": {
+      "type": "boolean",
+      "description": "Configure TypeScript in strict mode.",
+      "default": false
     }
   },
   "required": [


### PR DESCRIPTION
--strict option to configure TypeScript in strict mode when generating an app.

Replaces #397

Redo of #462 because of merge issues.

Updated with last schematics, and there is no side effect, so if you want to merge for v6, that would be great.

Note this PR is for v6 only, as `strictFunctionTypes` requires TS 2.6.

@hansl @filipesilva @Brocco 