### PR TITLE
fix(@angular-devkit/build-angular): add fileReplacements support to server

### DIFF
--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -70,9 +70,9 @@ export interface BuildWebpackServerSchema {
    */
   lazyModules?: string[];
   /**
-   * Defines the build environment.
+   * Replace files with other files in the build.
    */
-  environment?: string;
+  fileReplacements: FileReplacements[];
   /**
    * Define the output filename cache-busting hashing mode.
    */

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -32,9 +32,13 @@
       "description": "Defines the optimization level of the build.",
       "default": false
     },
-    "environment": {
-      "type": "string",
-      "description": "Defines the build environment."
+    "fileReplacements": {
+      "description": "Replace files with other files in the build.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/fileReplacement"
+      },
+      "default": []
     },
     "outputPath": {
       "type": "string",
@@ -155,5 +159,44 @@
     "outputPath",
     "main",
     "tsConfig"
-  ]
+  ],
+  "definitions": {
+    "fileReplacement": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "src": {
+              "type": "string"
+            },
+            "replaceWith": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "src",
+            "replaceWith"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "replace": {
+              "type": "string"
+            },
+            "with": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "replace",
+            "with"
+          ]
+        }
+      ]
+    }
+    
+  }
 }


### PR DESCRIPTION
`fileReplacements` is not yet supported on server target, and `environment` do nothing.
This pr restore environment/fileReplacements capabilities to server target.