### PR TITLE
fix(@angular-devkit/build-optimizer): don't assume enum values

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -13,7 +13,7 @@ export function testWrapEnums(content: string) {
   const regexes = [
     // tslint:disable:max-line-length
     /var (\S+) = \{\};\r?\n(\1\.(\S+) = \d+;\r?\n)+\1\[\1\.(\S+)\] = "\4";\r?\n(\1\[\1\.(\S+)\] = "\S+";\r?\n*)+/,
-    /var (\S+);(\/\*@__PURE__\*\/)*\r?\n\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = 0\] = "\4";(\s+\1\[\1\["\S+"\] = \d\] = "\S+";)*\r?\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/,
+    /var (\S+);(\/\*@__PURE__\*\/)*\r?\n\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = (\S+)\] = "\4";(\s+\1\[\1\["\S+"\] = (\S+)\] = "\S+";)*\r?\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/,
     /\/\*\* @enum \{\w+\} \*\//,
   // tslint:enable:max-line-length
   ];

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
@@ -58,6 +58,30 @@ describe('wrap-enums', () => {
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
 
+  it('wraps ts 2.3 - 2.6 enums in IIFE, even if they have funny numbers', () => {
+    const input = tags.stripIndent`
+      export var AnimatorControlState;
+      (function (AnimatorControlState) {
+          AnimatorControlState[AnimatorControlState["INITIALIZED"] = 1] = "INITIALIZED";
+          AnimatorControlState[AnimatorControlState["STARTED"] = 2] = "STARTED";
+          AnimatorControlState[AnimatorControlState["FINISHED"] = 3] = "FINISHED";
+          AnimatorControlState[AnimatorControlState["DESTROYED"] = 4] = "DESTROYED";
+      })(AnimatorControlState || (AnimatorControlState = {}));
+    `;
+    const output = tags.stripIndent`
+      export var AnimatorControlState = /*@__PURE__*/ (function (AnimatorControlState) {
+          AnimatorControlState[AnimatorControlState["INITIALIZED"] = 1] = "INITIALIZED";
+          AnimatorControlState[AnimatorControlState["STARTED"] = 2] = "STARTED";
+          AnimatorControlState[AnimatorControlState["FINISHED"] = 3] = "FINISHED";
+          AnimatorControlState[AnimatorControlState["DESTROYED"] = 4] = "DESTROYED";
+          return AnimatorControlState;
+      })({});
+    `;
+
+    expect(testWrapEnums(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
+
   it('wraps tsickle enums in IIFE', () => {
     const input = tags.stripIndent`
       /** @enum {number} */


### PR DESCRIPTION
Enum values were assumed to start with 0 and be digits. But enum values can be anything really.

When a enum declaration was not identified as an enum in a side effect free package, it would be identified as a top level IIFE (in another transform) and assumed pure. This drops the enum.

This PR fixes the behaviour by allowing the enum to be initialized with anything that doesn't have whitespaces. This is still limited and might lead to other false negatives that break things.

We should find a better way of identifying enums.

/cc @clydin

Fix https://github.com/angular/angular/issues/23400