### PR TITLE
fix(@schematic/angular): e2e should use the prefix

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -336,6 +336,7 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
+      prefix: options.prefix || 'app',
     };
     if (options.projectRoot !== undefined) {
       e2eOptions.projectRoot = 'e2e';

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
@@ -9,6 +9,6 @@ describe('workspace-project App', () => {
 
   it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('Welcome to app!');
+    expect(page.getParagraphText()).toEqual('Welcome to <%= prefix %>!');
   });
 });

--- a/packages/schematics/angular/e2e/schema.d.ts
+++ b/packages/schematics/angular/e2e/schema.d.ts
@@ -23,4 +23,8 @@ export interface Schema {
      * The name of the app being tested.
      */
     relatedAppName: string;
+    /**
+     * The prefix to apply.
+     */
+    prefix?: string;
 }

--- a/packages/schematics/angular/e2e/schema.json
+++ b/packages/schematics/angular/e2e/schema.json
@@ -26,6 +26,13 @@
     "relatedAppName": {
       "description": "The name of the app being tested.",
       "type": "string"
+    },
+    "prefix": {
+      "type": "string",
+      "format": "html-selector",
+      "description": "The prefix to apply to generated selectors.",
+      "default": "app",
+      "alias": "p"
     }
   },
   "required": [


### PR DESCRIPTION
Now that the CLI repects the prefix specified, the generated e2e test should also use it.

Currently a project generated with rc.5 fails the e2e test right away.

Another solution is to avoid giving the prefix option to the e2e schematic, and simply revert the title field of `app.component.ts` to `app`. See #721 