### PR TITLE
fix(@schematics/angular): use app as title

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.ts
+++ b/packages/schematics/angular/application/other-files/app.component.ts
@@ -31,5 +31,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.<%= styleext %>']<% } %>
 })
 export class AppComponent {
-  title = '<%= prefix %>';
+  title = 'app';
 }


### PR DESCRIPTION
If the title is dynamic and use the prefix, then the e2e generated test should too.
A simple way to avoid giving the prefix to the e2e schematic is to not use the prefix in the default title.

This is an alternative solution to #720 