### PR TITLE
fix(@angular/pwa): correct paths for manifest and icons

### DIFF
--- a/packages/angular/pwa/pwa/files/assets/manifest.json
+++ b/packages/angular/pwa/pwa/files/assets/manifest.json
@@ -4,46 +4,46 @@
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
   "display": "browser",
-  "Scope": "/",
+  "scope": "/",
   "start_url": "/",
   "icons": [
     {
-      "src": "images/icons/icon-72x72.png",
+      "src": "/assets/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-96x96.png",
+      "src": "/assets/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-128x128.png",
+      "src": "/assets/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-144x144.png",
+      "src": "/assets/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-152x152.png",
+      "src": "/assets/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-192x192.png",
+      "src": "/assets/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-384x384.png",
+      "src": "/assets/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "images/icons/icon-512x512.png",
+      "src": "/assets/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -189,7 +189,7 @@ function updateIndexFile(options: ServiceWorkerOptions): Rule {
 
     const indent = getIndent(closingHeadTagLine) + '  ';
     const itemsToAdd = [
-      '<link rel="manifest" href="./manifest.json">',
+      '<link rel="manifest" href="assets/manifest.json">',
       '<meta name="Description" content="Angular Application">',
       '<meta name="theme-color" content="#FFFFFF">',
     ];

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -101,7 +101,7 @@ describe('Service Worker Schematic', () => {
     const tree = schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
     const content = tree.readContent('projects/bar/src/index.html');
 
-    expect(content).toMatch(/<link rel="manifest" href="\.\/manifest.json">/);
+    expect(content).toMatch(/<link rel="manifest" href="assets\/manifest.json">/);
     expect(content).toMatch(/<meta name="Description" content="Angular Application">/);
     expect(content).toMatch(/<meta name="theme-color" content="#FFFFFF">/);
   });


### PR DESCRIPTION
Fixes #706, and the path to `manifest.json` in `index.html` was also wrong.

@hansl @filipesilva @Brocco 

2 side notes:
- beyond my skills, but those errors show tests are missing, because currently `@angular/pwa` was just not working at all, 
- `manifest.json` being in `assets` is risky, it may produce scope problems. `src` would be a better place. It would need custom config like the favicon in `angular.json` (to copy the file when building) and in `ngsw-config.json` (to cache the file).