### PR TITLE
Lazy chunk Webpack config adjustments

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -104,6 +104,12 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
             reuseExistingChunk: true,
             priority: 10,
           },
+          common: buildOptions.commonChunk && {
+            name: 'common',
+            chunks: 'async',
+            minChunks: 2,
+            priority: 5,
+          },
           vendors: false,
           vendor: buildOptions.vendorChunk && {
             name: 'vendor',

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -96,9 +96,14 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
     optimization: {
       runtimeChunk: 'single',
       splitChunks: {
-        chunks: buildOptions.commonChunk ? 'all' : 'initial',
         maxAsyncRequests: Infinity,
         cacheGroups: {
+          default: buildOptions.commonChunk && {
+            chunks: 'async',
+            minChunks: 2,
+            reuseExistingChunk: true,
+            priority: 10,
+          },
           vendors: false,
           vendor: buildOptions.vendorChunk && {
             name: 'vendor',


### PR DESCRIPTION
This prevents initial chunks (most importantly polyfills) from being split.  It also allows the creation of an overall application async common chunk for small common modules if the total is greater than 30Kb.