### PR TITLE
style: prepend Google @license to all files

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/base-href-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/base-href-webpack-plugin.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/base-href-webpack-plugin_spec.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/base-href-webpack-plugin_spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/index.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/lib/base-href-webpack/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/index.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/server.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/styles.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/test.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/typescript.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 import { tags, virtualFs } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/utils.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-webpack-failure-cb.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma-webpack-failure-cb.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/karma.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/suppress-entry-chunks-webpack-plugin.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/suppress-entry-chunks-webpack-plugin.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/webpack.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/plugins/webpack.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/find-up.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/find-up.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/is-directory.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/is-directory.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/package-chunk-sort.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/read-tsconfig.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/read-tsconfig.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 import * as ts from 'typescript';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/require-project-module.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/require-project-module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/service-worker/index.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/service-worker/index.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 import { Path, join, normalize, virtualFs, dirname, getSystemPath, tags, fragment } from '@angular-devkit/core';

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/stats.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/strip-bom.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/strip-bom.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // tslint:disable
 // TODO: cleanup this file, it's copied as is from Angular CLI.
 

--- a/packages/ngtools/webpack/src/type_checker_bootstrap.js
+++ b/packages/ngtools/webpack/src/type_checker_bootstrap.js
@@ -1,2 +1,9 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 require('../../../../lib/bootstrap-local');
 require('./type_checker_worker.ts');

--- a/tests/@angular_devkit/build_angular/hello-world-app/e2e/app.e2e-spec.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/e2e/app.e2e-spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { AppPage } from './app.po';
 
 describe('hello-world-app App', () => {

--- a/tests/@angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/e2e/app.po.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { browser, by, element } from 'protractor';
 
 export class AppPage {

--- a/tests/@angular_devkit/build_angular/hello-world-app/karma.conf.js
+++ b/tests/@angular_devkit/build_angular/hello-world-app/karma.conf.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 

--- a/tests/@angular_devkit/build_angular/hello-world-app/protractor.conf.js
+++ b/tests/@angular_devkit/build_angular/hello-world-app/protractor.conf.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Protractor configuration file, see link for more information
 // https://github.com/angular/protractor/blob/master/lib/config.ts
 

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.component.spec.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.component.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
 describe('AppComponent', () => {

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.component.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component } from '@angular/core';
 
 @Component({

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.module.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.server.module.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/app/app.server.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/environments/environment.prod.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/environments/environment.prod.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export const environment = {
   production: true
 };

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/environments/environment.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/environments/environment.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // The file contents for the current environment will overwrite these during build.
 // The build system defaults to the dev environment which uses `environment.ts`, but if you do
 // `ng build --env=prod` then `environment.prod.ts` will be used instead.

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/main.server.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/main.server.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { enableProdMode } from '@angular/core';
 
 import { environment } from './environments/environment';

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/main.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/polyfills.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/polyfills.ts
@@ -1,4 +1,11 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/**
  * This file includes polyfills needed by Angular and is loaded before the app.
  * You can add your own extra polyfills to this file.
  *

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/test.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/test.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import 'zone.js/dist/zone-testing';

--- a/tests/@angular_devkit/build_angular/hello-world-app/src/typings.d.ts
+++ b/tests/@angular_devkit/build_angular/hello-world-app/src/typings.d.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /* SystemJS module definition */
 declare var module: NodeModule;
 interface NodeModule {

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/karma.conf.js
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/karma.conf.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.component.spec.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.component.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { LibComponent } from './lib.component';

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.component.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, OnInit } from '@angular/core';
 
 @Component({

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.module.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule } from '@angular/core';
 import { LibComponent } from './lib.component';
 import { LibService } from './lib.service';

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.spec.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { TestBed, inject } from '@angular/core/testing';
 
 import { LibService } from './lib.service';

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 
 @Injectable()

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/public_api.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/public_api.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /*
  * Public API Surface of lib
  */

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/test.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/test.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // This file is required by karma.conf.js and loads recursively all the .spec and framework files
 
 import 'core-js/es7/reflect';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/benchmark.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/benchmark.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const fs = require('fs');
 const path = require('path');
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/e2e/app.e2e-spec.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/e2e/app.e2e-spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { browser, element, by } from 'protractor';
 
 describe('Webpack AIO app', function () {

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/protractor.config.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/protractor.config.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 exports.config = {
   allScriptsTimeout: 11000,
   specs: [

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/app.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/app.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, ElementRef, HostBinding, HostListener, OnInit,
          QueryList, ViewChild, ViewChildren } from '@angular/core';
 import { MdSidenav } from '@angular/material';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/app.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/app.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpModule } from '@angular/http';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/documents/document-contents.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/documents/document-contents.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export interface DocumentContents {
   /** The unique identifier for this document */
   id: string;

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/documents/document.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/documents/document.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/api/api-list.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/api/api-list.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /*
 * API List & Filter Component
 *

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/api/api.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/api/api.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable, OnDestroy } from '@angular/core';
 import { Http } from '@angular/http';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code-example.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code-example.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /* tslint:disable component-selector */
 import { Component, ElementRef, HostBinding, OnInit } from '@angular/core';
 import { getBoolFromAttribute } from 'app/shared/attribute-utils';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code-tabs.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code-tabs.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /* tslint:disable component-selector */
 import { Component, ElementRef, OnInit } from '@angular/core';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/code.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, ElementRef, ViewChild, OnChanges, OnDestroy, Input } from '@angular/core';
 import { Logger } from 'app/shared/logger.service';
 import { PrettyPrinter } from './pretty-printer.service';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/pretty-printer.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/code/pretty-printer.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 
 import { Observable } from 'rxjs/Observable';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor-list.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor-list.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, OnInit } from '@angular/core';
 import { ContributorGroup } from './contributors.model';
 import { ContributorService } from './contributor.service';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, Input } from '@angular/core';
 
 import { Contributor } from './contributors.model';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributor.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributors.model.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/contributor/contributors.model.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export class ContributorGroup {
   name: string;
   order: number;

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/current-location.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/current-location.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /* tslint:disable component-selector */
 import { Component } from '@angular/core';
 import { LocationService } from 'app/shared/location.service';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/embedded.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/embedded.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/live-example/live-example.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/live-example/live-example.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /* tslint:disable component-selector */
 import { Component, ElementRef, HostListener, Input, OnInit, AfterViewInit, ViewChild } from '@angular/core';
 import { Location } from '@angular/common';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource-list.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource-list.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, HostListener, OnInit } from '@angular/core';
 import { PlatformLocation } from '@angular/common';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource.model.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource.model.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 export class Category {
   id: string;    // "education"
   title: string; // "Education"

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/resource/resource.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/toc/toc.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/embedded/toc/toc.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, QueryList, ViewChildren } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/doc-viewer/doc-viewer.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/doc-viewer/doc-viewer.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import {
   Component, ComponentFactory, ComponentFactoryResolver, ComponentRef,
   DoCheck, ElementRef, EventEmitter, Injector, Input, OnDestroy,

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/doc-viewer/dt.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/doc-viewer/dt.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, ElementRef, EventEmitter, Input, Output, ViewChild } from '@angular/core';
 import { DocumentContents } from 'app/documents/document.service';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/footer/footer.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/footer/footer.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, Input } from '@angular/core';
 
 import { NavigationNode, VersionInfo } from 'app/navigation/navigation.service';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/nav-item/nav-item.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/nav-item/nav-item.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { NavigationNode } from 'app/navigation/navigation.model';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/nav-menu/nav-menu.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/nav-menu/nav-menu.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, Input } from '@angular/core';
 import { CurrentNode, NavigationNode } from 'app/navigation/navigation.service';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/top-menu/top-menu.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/layout/top-menu/top-menu.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, Input } from '@angular/core';
 import { NavigationNode } from 'app/navigation/navigation.service';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/navigation/navigation.model.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/navigation/navigation.model.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Pulled all interfaces out of `navigation.service.ts` because of this:
 // https://github.com/angular/angular-cli/issues/2034
 // Then re-export them from `navigation.service.ts`

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/navigation/navigation.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/navigation/navigation.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-box/search-box.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-box/search-box.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, OnInit, ViewChild, ElementRef, EventEmitter, Output } from '@angular/core';
 import { LocationService } from 'app/shared/location.service';
 import { Subject } from 'rxjs/Subject';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-results/search-results.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-results/search-results.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, EventEmitter, HostListener, OnDestroy, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subscription } from 'rxjs/Subscription';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-worker.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search-worker.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 'use strict';
 
 /* eslint-env worker */

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/search/search.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /*
 Copyright 2016 Google Inc. All Rights Reserved.
 Use of this source code is governed by an MIT-style license that

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/attribute-utils.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/attribute-utils.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Utilities for processing HTML element attributes
 import { ElementRef } from '@angular/core';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/copier.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/copier.service.ts
@@ -1,4 +1,11 @@
 /**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+/**
  * This class is based on the code in the following projects:
  *
  * - https://github.com/zenorocha/select

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/custom-md-icon-registry.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/custom-md-icon-registry.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { InjectionToken, Inject, Injectable } from '@angular/core';
 import { of } from 'rxjs/observable/of';
 import { MdIconRegistry } from '@angular/material';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/ga.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/ga.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 
 import { environment } from '../../environments/environment';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/location.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/location.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { Location, PlatformLocation } from '@angular/common';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/logger.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/logger.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 import { environment } from '../../environments/environment';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/scroll-spy.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/scroll-spy.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Inject, Injectable } from '@angular/core';
 import { DOCUMENT } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/scroll.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/scroll.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable, Inject } from '@angular/core';
 import { PlatformLocation } from '@angular/common';
 import { DOCUMENT } from '@angular/platform-browser';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/select/select.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/select/select.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component, ElementRef, EventEmitter, HostListener, Input, Output, OnInit } from '@angular/core';
 
 export interface Option {

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/shared.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/shared.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { SelectComponent } from './select/select.component';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/toc.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/toc.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Inject, Injectable } from '@angular/core';
 import { DOCUMENT, DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { ReplaySubject } from 'rxjs/ReplaySubject';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/web-worker.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/shared/web-worker.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 /*
 Copyright 2016 Google Inc. All Rights Reserved.
 Use of this source code is governed by an MIT-style license that

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/global.value.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/global.value.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { InjectionToken } from '@angular/core';
 
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-update-notifications.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-update-notifications.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Inject, Injectable } from '@angular/core';
 import { MdSnackBar, MdSnackBarConfig, MdSnackBarRef } from '@angular/material';
 import { Subject } from 'rxjs/Subject';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-updates.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-updates.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule } from '@angular/core';
 import { MdSnackBarModule } from '@angular/material';
 import { ServiceWorkerModule } from '@angular/service-worker';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-updates.service.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/app/sw-updates/sw-updates.service.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable, OnDestroy } from '@angular/core';
 import { NgServiceWorker } from '@angular/service-worker';
 import { Observable } from 'rxjs/Observable';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/assets/js/prettify.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/assets/js/prettify.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 !function(){/*
 
  Copyright (C) 2006 Google Inc.

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/environments/environment.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/environments/environment.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // This is for the production site, which is hosted at https://angular.io
 export const environment = {
   gaId: 'UA-8594346-15',

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/main.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { ApplicationRef, enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/polyfills.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/src/polyfills.ts
@@ -1,1 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import 'zone.js/dist/zone';

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.common.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.common.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const PurifyPlugin = require('@angular-devkit/build-optimizer').PurifyPlugin;
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.no-ngo.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.no-ngo.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.old-ngo.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/aio-app/webpack.config.old-ngo.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/benchmark.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/benchmark.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const fs = require('fs');
 const path = require('path');
 

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/e2e/app.e2e-spec.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/e2e/app.e2e-spec.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { browser, element, by } from 'protractor';
 
 describe('Webpack simple app', function () {

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/protractor.config.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/protractor.config.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 exports.config = {
   allScriptsTimeout: 11000,
   specs: [

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/app.component.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/app.component.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Component } from '@angular/core';
 import { MyInjectable } from './injectable';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/app.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/app.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule, Component } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/feature.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/feature.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule, Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/injectable.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/injectable.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { Injectable } from '@angular/core';
 
 

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/lazy.module.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/app/lazy.module.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { NgModule, Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { HttpModule, Http } from '@angular/http';

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/main.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/main.ts
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/polyfills.ts
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/src/polyfills.ts
@@ -1,1 +1,8 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 import 'zone.js/dist/zone';

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.common.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.common.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const PurifyPlugin = require('@angular-devkit/build-optimizer').PurifyPlugin;
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.no-ngo.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.no-ngo.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.old-ngo.js
+++ b/tests/@angular_devkit/build_optimizer/webpack/simple-app/webpack.config.old-ngo.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 const path = require('path');
 
 const config = require('./webpack.config.common.js');

--- a/tests/@angular_devkit/build_webpack/hello-world-app/karma.conf.js
+++ b/tests/@angular_devkit/build_webpack/hello-world-app/karma.conf.js
@@ -1,3 +1,10 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 


### PR DESCRIPTION
Prepends the standard @license doc to all `.{js,ts}` files that didn't already have one.