### PR TITLE
fix(@angular-devkit/schematics): fix __dasherize__ name

### DIFF
--- a/packages/schematics/angular/ng-new/index.ts
+++ b/packages/schematics/angular/ng-new/index.ts
@@ -60,7 +60,6 @@ export default function (options: NgNewOptions): Rule {
         schematic('workspace', workspaceOptions),
         schematic('application', applicationOptions),
         move(options.directory || options.name),
-        tree => Tree.optimize(tree),
       ]),
     ),
     (host: Tree, context: SchematicContext) => {


### PR DESCRIPTION
Sometimes, some actions are not properly optimized. I havent had time to fully
investigate, and we will rework the ActionList entirely (making it more solid
and in line with the rest of the pipeline), so this error will move away properly.
In the meantime, when creating a source, optimizing the tree early helps
tremendously, and since it is not merged (and built from an empty tree),
there is no side effect to optimizing.