### PR TITLE
fix(@angular-devkit/build-angular): support some browser options in dev-server

### DIFF
--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -51,6 +51,15 @@ export interface DevServerBuilderOptions {
   watch: boolean;
   hmrWarning: boolean;
   servePathDefaultWarning: boolean;
+
+  optimization?: boolean;
+  aot?: boolean;
+  sourceMap?: boolean;
+  evalSourceMap?: boolean;
+  vendorChunk?: boolean;
+  commonChunk?: boolean;
+  baseHref?: string;
+  progress?: boolean;
 }
 
 interface WebpackDevServerConfigurationOptions {
@@ -424,6 +433,20 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     const browserTargetSpec = { project, target, configuration, overrides };
     const builderConfig = architect.getBuilderConfiguration<BrowserBuilderSchema>(
       browserTargetSpec);
+
+    // Update the browser options with the same options we support in serve, if defined.
+    builderConfig.options = {
+      ...(options.optimization !== undefined ? { optimization: options.optimization } : {}),
+      ...(options.aot !== undefined ? { aot: options.aot } : {}),
+      ...(options.sourceMap !== undefined ? { sourceMap: options.sourceMap } : {}),
+      ...(options.evalSourceMap !== undefined ? { evalSourceMap: options.evalSourceMap } : {}),
+      ...(options.vendorChunk !== undefined ? { vendorChunk: options.vendorChunk } : {}),
+      ...(options.commonChunk !== undefined ? { commonChunk: options.commonChunk } : {}),
+      ...(options.baseHref !== undefined ? { baseHref: options.baseHref } : {}),
+      ...(options.progress !== undefined ? { progress: options.progress } : {}),
+
+      ...builderConfig.options,
+    };
 
     return architect.getBuilderDescription(builderConfig).pipe(
       concatMap(browserDescription =>

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -77,6 +77,46 @@
       "type": "boolean",
       "description": "Show a warning when deploy-url/base-href use unsupported serve path values.",
       "default": true
+    },
+    "optimization": {
+      "type": "boolean",
+      "description": "Defines the optimization level of the build."
+    },
+    "aot": {
+      "type": "boolean",
+      "description": "Build using Ahead of Time compilation."
+    },
+    "sourceMap": {
+      "type": "boolean",
+      "description": "Output sourcemaps."
+    },
+    "evalSourceMap": {
+      "type": "boolean",
+      "description": "Output in-file eval sourcemaps."
+    },
+    "vendorChunk": {
+      "type": "boolean",
+      "description": "Use a separate bundle containing only vendor libraries."
+    },
+    "commonChunk": {
+      "type": "boolean",
+      "description": "Use a separate bundle containing code used across multiple bundles."
+    },
+    "baseHref": {
+      "type": "string",
+      "description": "Base url for the application being built."
+    },
+    "deployUrl": {
+      "type": "string",
+      "description": "URL where files will be deployed."
+    },
+    "verbose": {
+      "type": "boolean",
+      "description": "Adds more details to output logging."
+    },
+    "progress": {
+      "type": "boolean",
+      "description": "Log progress to the console while building."
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
This will allow people to override some flags from a base browser target, either from
the command line or from their serve directly.

The options chosen are kinda arbitrary. I simply looked at what made sense.

Fix angular/angular-cli#10304