### PR TITLE
fix(@schematics/angular): generate app-shell options properly

### DIFF
--- a/packages/schematics/angular/app-shell/index.ts
+++ b/packages/schematics/angular/app-shell/index.ts
@@ -187,9 +187,12 @@ function addAppShellConfigToWorkspace(options: AppShellOptions): Rule {
     const workspacePath = getWorkspacePath(host);
 
     const appShellTarget: JsonObject = {
-      browserTarget: `${options.clientProject}:build`,
-      serverTarget: `${options.clientProject}:server`,
-      route: options.route,
+      builder: '@angular-devkit/build-angular:app-shell',
+      options: {
+        browserTarget: `${options.clientProject}:build`,
+        serverTarget: `${options.clientProject}:server`,
+        route: options.route,
+      },
     };
 
     if (!workspace.projects[options.clientProject]) {

--- a/packages/schematics/angular/app-shell/index_spec.ts
+++ b/packages/schematics/angular/app-shell/index_spec.ts
@@ -66,9 +66,9 @@ describe('App Shell Schematic', () => {
     const content = tree.readContent(filePath);
     const workspace = JSON.parse(content);
     const target = workspace.projects.bar.architect['app-shell'];
-    expect(target.browserTarget).toEqual('bar:build');
-    expect(target.serverTarget).toEqual('bar:server');
-    expect(target.route).toEqual('shell');
+    expect(target.options.browserTarget).toEqual('bar:build');
+    expect(target.options.serverTarget).toEqual('bar:server');
+    expect(target.options.route).toEqual('shell');
   });
 
   it('should add router module to client app module', () => {


### PR DESCRIPTION
Options are in the "options" key.

Fix angular/angular-cli#10379