### PR TITLE
fix(@angular-devkit/build-angular): sync ajv versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@types/source-map": "0.5.2",
     "@types/webpack": "^3.8.2",
     "@types/webpack-sources": "^0.1.3",
-    "ajv": "^6.4.0",
+    "ajv": "~6.4.0",
     "autoprefixer": "^8.1.0",
     "bootstrap": "^4.0.0",
     "cache-loader": "^1.2.2",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -13,7 +13,7 @@
     "@angular-devkit/build-optimizer": "0.0.0",
     "@angular-devkit/core": "0.0.0",
     "@ngtools/webpack": "0.0.0",
-    "ajv": "^6.0.0",
+    "ajv": "~6.4.0",
     "autoprefixer": "^8.1.0",
     "cache-loader": "^1.2.2",
     "chalk": "~2.2.2",


### PR DESCRIPTION
All packages now use `~6.4.0`.