### PR TITLE
feat(@schematics/angular): enable 'no-template-call-expression' rule

### DIFF
--- a/packages/schematics/angular/workspace/files/tslint.json
+++ b/packages/schematics/angular/workspace/files/tslint.json
@@ -116,6 +116,7 @@
       "check-separator",
       "check-type"
     ],
+    "no-template-call-expression": true,
     "no-output-on-prefix": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,

--- a/tests/@angular_devkit/build_angular/hello-world-app/tslint.json
+++ b/tests/@angular_devkit/build_angular/hello-world-app/tslint.json
@@ -117,6 +117,7 @@
       "check-separator",
       "check-type"
     ],
+    "no-template-call-expression": true,
     "directive-selector": [
       true,
       "attribute",

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/tslint.json
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/tslint.json
@@ -117,6 +117,7 @@
       "check-separator",
       "check-type"
     ],
+    "no-template-call-expression": true,
     "no-output-on-prefix": true,
     "use-input-property-decorator": true,
     "use-output-property-decorator": true,


### PR DESCRIPTION
At ng-conf, there was a talk on avoiding binding to function call expression in template to improve change detection performance. Several months ago, I contributed a rule to `codelyzer` that will flag any binding to call expression in template (mgechev/codelyzer#478). This PR enables that rule in the `tslint.json` schematic for Angular projects.