### PR TITLE
feat(@angular-devkit/build-ng-packagr): permit to set a custom TsConfig file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ node_modules/
 tmp/
 npm-debug.log*
 yarn-error.log*
+.ng_pkg_build/
 
 # Mac OSX Finder files.
 **/.DS_Store

--- a/packages/angular_devkit/build_ng_packagr/src/build/index.ts
+++ b/packages/angular_devkit/build_ng_packagr/src/build/index.ts
@@ -27,6 +27,7 @@ function requireProjectModule(root: string, moduleName: string) {
 
 export interface NgPackagrBuilderOptions {
   project: string;
+  tsConfig?: string;
 }
 
 export class NgPackagrBuilder implements Builder<NgPackagrBuilderOptions> {
@@ -46,9 +47,15 @@ export class NgPackagrBuilder implements Builder<NgPackagrBuilderOptions> {
         getSystemPath(root), 'ng-packagr') as typeof ngPackagr;
       const packageJsonPath = getSystemPath(resolve(root, normalize(options.project)));
 
-      projectNgPackagr.ngPackagr()
-        .forProject(packageJsonPath)
-        .build()
+      const ngPkgProject = projectNgPackagr.ngPackagr()
+        .forProject(packageJsonPath);
+
+      if (options.tsConfig) {
+        const tsConfigPath = getSystemPath(resolve(root, normalize(options.tsConfig)));
+        ngPkgProject.withTsConfig(tsConfigPath);
+      }
+
+      ngPkgProject.build()
         .then(() => {
           obs.next({ success: true });
           obs.complete();

--- a/packages/angular_devkit/build_ng_packagr/src/build/schema.json
+++ b/packages/angular_devkit/build_ng_packagr/src/build/schema.json
@@ -6,6 +6,10 @@
     "project": {
       "type": "string",
       "description": "The file path of the package.json for distribution via npm."
+    },
+    "tsConfig": {
+      "type": "string",
+      "description": "The file path of the TypeScript configuration file."
     }
   },
   "additionalProperties": false,

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/angular.json
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/angular.json
@@ -9,7 +9,8 @@
         "build": {
           "builder": "../../../../packages/angular_devkit/build_ng_packagr:build",
           "options": {
-            "project": "projects/lib/ng-package.json"
+            "project": "projects/lib/ng-package.json",
+            "tsConfig": "projects/lib/tsconfig.lib.json"
           }
         },
         "test": {

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.ts
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/src/lib/lib.service.ts
@@ -5,4 +5,8 @@ export class LibService {
 
   constructor() { }
 
+  testEs2016() {
+    return ['foo', 'bar'].includes('foo');
+  }
+
 }

--- a/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/tsconfig.lib.json
+++ b/tests/@angular_devkit/build_ng_packagr/ng-packaged/projects/lib/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "moduleResolution": "node",
+    "sourceMap": true,
+    "inlineSources": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "importHelpers": true,
+    "lib": ["dom", "es2016"]
+  }
+}


### PR DESCRIPTION
Add a new tsConfig option in order to permit to use a custom tsConfig file when using @angular-devkit/build-ng-packagr as a build target in angular-cli.

This is, for example, needed in order to resolve this kind of issue : 
```
$ ng build -- --project myLib
BUILD ERROR
projects/common/src/lib/foo/bar.directive.ts(134,41): error TS2339: Property 'includes' does not exist on type 'string[]'.
```
See the evolution of tests for an example. This example show how to change the ES level in lib and target 
All the other options are required for now if we don't want to break the build. I will remove them and bump the ng-packagr dependency version in another PR once / if dherges/ng-packagr#786 is released 

No breaking change.