### PR TITLE
fix(@ngtools/webpack): Validate wildcard path replacements

### DIFF
--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -96,10 +96,33 @@ export function resolveWithPaths(
       replacement = prefix + pathMapOptions[0].partial + suffix;
     }
 
-    request.request = path.resolve(compilerOptions.baseUrl || '', replacement);
-    callback(null, request);
+    replacement = path.resolve(compilerOptions.baseUrl || '', replacement);
 
-    return;
+    if (host.fileExists(replacement)) {
+      // Found a definite match
+      request.request = replacement;
+      callback(null, request);
+      return;
+    }
+    else {
+      // Could be an extensionless import that TS can resolve?
+      const moduleResolver = ts.resolveModuleName(
+        replacement,
+        request.contextInfo.issuer,
+        compilerOptions,
+        host,
+        cache,
+      );
+
+      const moduleFilePath = moduleResolver.resolvedModule
+                             && moduleResolver.resolvedModule.resolvedFileName;
+
+      if (moduleFilePath) {
+        request.request = moduleFilePath;
+        callback(null, request);
+        return;
+      }
+    }
   }
 
   const moduleResolver = ts.resolveModuleName(


### PR DESCRIPTION
As described in [this angular-cli issue](https://github.com/angular/angular-cli/issues/10376), the logic for handling wildcard paths in the paths plugin is broken, does not match how TypeScript works, and breaks non-relative module imports that happen to match a wildcard path.

As described in the [module resolution docs](http://www.typescriptlang.org/docs/handbook/module-resolution.html), TypeScript considers each mapping in turn as a way to _potentially_ turn a non-relative import into a relative one. However, this mapping is used if and only if the resulting path actually matches a file that exists on disk. If an import matches a path, but does not resolve to a real file, TypeScript will fall back to regular node module resolution.

For example, if I have a path mapping `"*": ["./src/app"]`, then this will match _any_ import, including an import of `'@angular/core'`. As such, TypeScript will initially try to resolve this as a file with the path `{baseUrl}/./src/@angular/core`. However, when it cannot find a file in this location, it will fall back to regular resolution, likely loading the module from `{baseUrl}/node_modules/@angular/core`.

As it stands, the paths plugin does _not_ validate whether the mapped file exists. It assumes it does and passes it on to Webpack without checking. The result is that basic wildcard mappings, of the type given in the TypeScript documentation, break things, because they cause the plugin to transform non-relative module imports into invalid, relative mappings.

This change attempts to fix the problem by validating whether the result of applying a mapping matches a real file. It considers two possibilities:

 1. The mapped path exactly matches a file on disk. E.g. an import of `style/something.css`, where there is a file `{baseUrl}/src/app/style/something.css`.
 2. The mapped path is an extensionless import that TypeScript can resolve. E.g. an import of `core/utils`, where there is a file `{baseUrl}/src/app/core/utils.ts` (or `.tsx`, etc.).

Even with this change, things probably still don't fully match how TypeScript handles path mappings, but it should be considerably closer.