### PR TITLE
fix(@schematics/angular): update serviceworker config for 6.x files

### DIFF
--- a/packages/schematics/angular/service-worker/files/ngsw-config.json
+++ b/packages/schematics/angular/service-worker/files/ngsw-config.json
@@ -6,12 +6,9 @@
     "resources": {
       "files": [
         "/favicon.ico",
-        "/index.html"
-      ],
-      "versionedFiles": [
-        "/*.bundle.css",
-        "/*.bundle.js",
-        "/*.chunk.js"
+        "/index.html",
+        "/*.css",
+        "/*.js"
       ]
     }
   }, {


### PR DESCRIPTION
This should eventually be auto-generated during the `ng add`/etc. operation based on the project's configuration and potentially be augmented at build time for any additional processed resources.

Fixes: angular/angular-cli#10395