### PR TITLE
fix(@ngtools/webpack): Do not apply ts mappings to webpack amd requests

### DIFF
--- a/packages/ngtools/webpack/src/paths-plugin.ts
+++ b/packages/ngtools/webpack/src/paths-plugin.ts
@@ -42,6 +42,13 @@ export function resolveWithPaths(
     return;
   }
 
+  // Amd requests are not mapped
+  if (originalRequest.startsWith('!!webpack amd')) {
+    callback(null, request);
+
+    return;
+  }
+
   // check if any path mapping rules are relevant
   const pathMapOptions = [];
   for (const pattern in compilerOptions.paths) {


### PR DESCRIPTION
Fix #758