### PR TITLE
feat(@angular-devkit/build-angular): add sourcemaps for external libr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9771,6 +9771,42 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
+    "source-map-loader": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-0.2.3.tgz",
+      "integrity": "sha1-1LDIzUfVTtzj5r+g9SP0UrWw5SE=",
+      "requires": {
+        "async": "^2.5.0",
+        "loader-utils": "~0.2.2",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+          "requires": {
+            "big.js": "^3.1.3",
+            "emojis-list": "^2.0.0",
+            "json5": "^0.5.0",
+            "object-assign": "^4.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
+        }
+      }
+    },
     "source-map-resolve": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,7 @@
     "semver-intersect": "^1.1.2",
     "source-map": "^0.5.6",
     "source-map-support": "^0.5.0",
+    "source-map-loader": "^0.2.3",
     "stats-webpack-plugin": "^0.6.2",
     "style-loader": "^0.21.0",
     "stylus": "^0.54.5",

--- a/packages/angular_devkit/build_angular/package.json
+++ b/packages/angular_devkit/build_angular/package.json
@@ -41,6 +41,7 @@
     "rxjs": "^6.0.0",
     "sass-loader": "^7.0.1",
     "source-map-support": "^0.5.0",
+    "source-map-loader": "^0.2.3",
     "stats-webpack-plugin": "^0.6.2",
     "style-loader": "^0.21.0",
     "stylus": "^0.54.5",

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/build-options.ts
@@ -18,6 +18,7 @@ export interface BuildOptions {
   outputPath: string;
   aot?: boolean;
   sourceMap?: boolean;
+  vendorSourceMap?: boolean;
   evalSourceMap?: boolean;
   vendorChunk?: boolean;
   commonChunk?: boolean;

--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -158,6 +158,17 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     extraPlugins.push(new StatsPlugin('stats.json', 'verbose'));
   }
 
+  let sourceMapUseRule;
+  if (buildOptions.sourceMap && buildOptions.vendorSourceMap) {
+    sourceMapUseRule = {
+      use: [
+        {
+          loader: 'source-map-loader'
+        }
+      ]
+    }
+  }
+
   let buildOptimizerUseRule;
   if (buildOptions.buildOptimizer) {
     buildOptimizerUseRule = {
@@ -273,6 +284,12 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
         {
           test: /\.js$/,
           ...buildOptimizerUseRule,
+        },
+        {
+          test: /\.js$/,
+          exclude: /(ngfactory|ngstyle).js$/,
+          enforce: 'pre',
+          ...sourceMapUseRule,
         },
       ]
     },

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -67,6 +67,11 @@ export interface BrowserBuilderSchema {
   sourceMap: boolean;
 
   /**
+   * Resolve vendor packages sourcemaps.
+   */
+  vendorSourceMap?: boolean;
+
+  /**
    * Output in-file eval sourcemaps.
    */
   evalSourceMap: boolean;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -80,6 +80,11 @@
       "description": "Output sourcemaps.",
       "default": true
     },
+    "vendorSourceMap": {
+      "type": "boolean",
+      "description": "Resolve vendor packages sourcemaps.",
+      "default": false
+    },
     "evalSourceMap": {
       "type": "boolean",
       "description": "Output in-file eval sourcemaps.",

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -90,6 +90,11 @@
       "type": "boolean",
       "description": "Output sourcemaps."
     },
+    "vendorSourceMap": {
+      "type": "boolean",
+      "description": "Resolve vendor packages sourcemaps.",
+      "default": false
+    },
     "evalSourceMap": {
       "type": "boolean",
       "description": "Output in-file eval sourcemaps."

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -64,8 +64,16 @@
     },
     "sourceMap": {
       "type": "boolean",
-      "description": "Output sourcemaps.",
-      "default": true
+      "description": "Output sourcemaps."
+    },
+    "vendorSourceMap": {
+      "type": "boolean",
+      "description": "Resolve vendor packages sourcemaps.",
+      "default": false
+    },
+    "evalSourceMap": {
+      "type": "boolean",
+      "description": "Output in-file eval sourcemaps."
     },
     "progress": {
       "type": "boolean",

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -31,6 +31,10 @@ export interface BuildWebpackServerSchema {
    */
   vendorChunk?: boolean;
   /**
+   * Resolve vendor packages sourcemaps.
+   */
+  vendorSourceMap?: boolean;
+  /**
    * Output in-file eval sourcemaps.
    */
   evalSourceMap?: boolean;

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -49,6 +49,11 @@
       "description": "Output sourcemaps.",
       "default": true
     },
+    "vendorSourceMap": {
+      "type": "boolean",
+      "description": "Resolve vendor packages sourcemaps.",
+      "default": false
+    },
     "evalSourceMap": {
       "type": "boolean",
       "description": "Output in-file eval sourcemaps.",

--- a/packages/angular_devkit/build_angular/test/browser/vendor-source-map_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/vendor-source-map_spec_large.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import { join, normalize, virtualFs } from '@angular-devkit/core';
+import * as path from 'path';
+import { tap } from 'rxjs/operators';
+import { Timeout, browserTargetSpec, host, runTargetSpec } from '../utils';
+
+describe('Browser Builder external source map', () => {
+  const outputPath = normalize('dist');
+
+  beforeEach(done => host.initialize().toPromise().then(done, done.fail));
+  afterEach(done => host.restore().toPromise().then(done, done.fail));
+
+  it('works', (done) => {
+    const overrides = { sourceMap: true, vendorSourceMap: true };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        const fileName = join(outputPath, 'vendor.js.map');
+        expect(host.scopedSync().exists(fileName)).toBe(true);
+        const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+        // this is due the fact that some vendors like `tslib` sourcemaps to js files
+        const sourcePath = JSON.parse(content).sources[0];
+        expect(path.extname(sourcePath)).toBe('.ts', `${sourcePath} extention should be '.ts'`);
+      }),
+    ).toPromise().then(done, done.fail);
+  }, Timeout.Basic);
+
+  it('does not map sourcemaps from external library when disabled', (done) => {
+    const overrides = { sourceMap: true, vendorSourceMap: false };
+
+    runTargetSpec(host, browserTargetSpec, overrides).pipe(
+      tap((buildEvent) => expect(buildEvent.success).toBe(true)),
+      tap(() => {
+        const fileName = join(outputPath, 'vendor.js.map');
+        expect(host.scopedSync().exists(fileName)).toBe(true);
+        const content = virtualFs.fileBufferToString(host.scopedSync().read(normalize(fileName)));
+        // this is due the fact that some vendors like `tslib` sourcemaps to js files
+        const sourcePath = JSON.parse(content).sources[0];
+        expect(path.extname(sourcePath)).toBe('.js', `${sourcePath} extention should be '.js'`);
+      }),
+    ).toPromise().then(done, done.fail);
+  }, Timeout.Basic);
+
+});


### PR DESCRIPTION
At the moment sourcemaps for node_modules are not being loaded.

This is useful for debugging and also if you need this for error reporting during production build, In case you are concerned about build time related performance, we can make this enabled/disabled via a flag.

I'd also suggest to have an option, to set the type of `devtool`, for some users with large apps this will improve the increased the build speed.

PS: I can do the above in a separate Pr, if you like the idea.