### PR TITLE
Feature Suggestion: Create a HostComponent in all new component specs

### DIFF
--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -29,7 +29,7 @@ describe('<%= classify(name) %>Component', () => {
   }));
 
   beforeEach(() => {
-    fixture = TestBed.createComponent(<%= classify(name) %>Component);
+    fixture = TestBed.createComponent(HostComponent);
     host = fixture.componentInstance;
     fixture.detectChanges();
     component = host.componentUnderTest;

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -10,7 +10,7 @@ import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.compone
   `,
 })
 class HostComponent {
-  @ViewChild(SimplePlaylistVideoComponent) componentUnderTest: SimplePlaylistVideoComponent;
+  @ViewChild(<%= classify(name) %>Component) componentUnderTest: <%= classify(name) %>Component;
 }
 
 describe('<%= classify(name) %>Component', () => {

--- a/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
+++ b/packages/schematics/angular/component/files/__name@dasherize@if-flat__/__name@dasherize__.component.spec.ts
@@ -1,22 +1,38 @@
+import { Component, ViewChild } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { <%= classify(name) %>Component } from './<%= dasherize(name) %>.component';
 
+@Component({
+  selector: 'app-host',
+  template: `
+    <app-<%= dasherize(name) %>></app-<%= dasherize(name) %>>
+  `,
+})
+class HostComponent {
+  @ViewChild(SimplePlaylistVideoComponent) componentUnderTest: SimplePlaylistVideoComponent;
+}
+
 describe('<%= classify(name) %>Component', () => {
   let component: <%= classify(name) %>Component;
+  let host: HostComponent;
   let fixture: ComponentFixture<<%= classify(name) %>Component>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ <%= classify(name) %>Component ]
+      declarations: [
+        <%= classify(name) %>Component,
+        HostComponent
+      ]
     })
     .compileComponents();
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(<%= classify(name) %>Component);
-    component = fixture.componentInstance;
+    host = fixture.componentInstance;
     fixture.detectChanges();
+    component = host.componentUnderTest;
   });
 
   it('should create', () => {


### PR DESCRIPTION
This is a feature request (feature change request?) that I had in mind. I did this as a PR so you could easily see what I am suggesting. If you like it, I'll finish off everything and get the PR up to spec.

### Steps Before Complete
- [ ] Get approval of this idea from a member of the angular/devkit team
- [ ] Properly test the changes I've suggested
- [ ] Rewrite commit message to adhere to the proper standards for Angular

### The Idea
> I know that this should perhaps not be the default right away, but maybe to be considered at a major version bump.

I usually end up creating a `HostComponent` for every test I make in Angular. This change extends the current spec setup for a new component to include a bunch of host component boilerplate right from the get-go. I figure that since some components will not use `@Input` or `@Output`, the presence of the host will not alter the test outcomes anyway.

Thoughts are welcome. Especially since there may be a better strategy for testing components which accept `@Input` or produce `@Output` of which I am not aware. I was inspired by the [Angular documentation](https://angular.io/guide/testing#component-inside-a-test-host).