### PR TITLE
fix(@angular-devkit/build-angular): avoid reusing main chunk for common modules

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/browser.ts
@@ -101,13 +101,13 @@ export function getBrowserConfig(wco: WebpackConfigOptions) {
           default: buildOptions.commonChunk && {
             chunks: 'async',
             minChunks: 2,
-            reuseExistingChunk: true,
             priority: 10,
           },
           common: buildOptions.commonChunk && {
             name: 'common',
             chunks: 'async',
             minChunks: 2,
+            enforce: true,
             priority: 5,
           },
           vendors: false,


### PR DESCRIPTION
Fix https://github.com/angular/devkit/issues/763