### PR TITLE
fix(@schematics/angular): fix universal schematic

### DIFF
--- a/packages/schematics/angular/universal/files/src/__tsconfigFileName__.json
+++ b/packages/schematics/angular/universal/files/src/__tsconfigFileName__.json
@@ -2,6 +2,7 @@
   "extends": "./<%= tsConfigExtends %>",
   "compilerOptions": {
     "outDir": "<%= outDir %>-server",
+    "baseUrl": ".",
     "module": "commonjs"
   },
   "angularCompilerOptions": {

--- a/packages/schematics/angular/universal/index.ts
+++ b/packages/schematics/angular/universal/index.ts
@@ -64,24 +64,25 @@ function getClientArchitect(
 
 function updateConfigFile(options: UniversalOptions): Rule {
   return (host: Tree) => {
+    const workspace = getWorkspace(host);
+    if (!workspace.projects[options.clientProject]) {
+      throw new SchematicsException(`Client app ${options.clientProject} not found.`);
+    }
+
+    const clientProject = workspace.projects[options.clientProject];
+    if (!clientProject.architect) {
+      throw new Error('Client project architect not found.');
+    }
+
     const builderOptions: JsonObject = {
       outputPath: `dist/${options.clientProject}-server`,
-      main: `projects/${options.clientProject}/src/main.server.ts`,
-      tsConfig: `projects/${options.clientProject}/tsconfig.server.json`,
+      main: `${clientProject.root}src/main.server.ts`,
+      tsConfig: `${clientProject.root}src/tsconfig.server.json`,
     };
     const serverTarget: JsonObject = {
       builder: '@angular-devkit/build-angular:server',
       options: builderOptions,
     };
-    const workspace = getWorkspace(host);
-
-    if (!workspace.projects[options.clientProject]) {
-      throw new SchematicsException(`Client app ${options.clientProject} not found.`);
-    }
-    const clientProject = workspace.projects[options.clientProject];
-    if (!clientProject.architect) {
-      throw new Error('Client project architect not found.');
-    }
     clientProject.architect.server = serverTarget;
 
     const workspacePath = getWorkspacePath(host);

--- a/packages/schematics/angular/universal/index_spec.ts
+++ b/packages/schematics/angular/universal/index_spec.ts
@@ -59,17 +59,18 @@ describe('Universal Schematic', () => {
 
   it('should create a tsconfig file', () => {
     const tree = schematicRunner.runSchematic('universal', defaultOptions, appTree);
-    const filePath = '/projects/bar/tsconfig.server.json';
+    const filePath = '/projects/bar/src/tsconfig.server.json';
     expect(tree.exists(filePath)).toEqual(true);
     const contents = tree.readContent(filePath);
     expect(JSON.parse(contents)).toEqual({
       extends: './tsconfig.app.json',
       compilerOptions: {
         outDir: '../../out-tsc/app-server',
+        baseUrl: '.',
         module: 'commonjs',
       },
       angularCompilerOptions: {
-        entryModule: 'src/app/app.server.module#AppServerModule',
+        entryModule: 'app/app.server.module#AppServerModule',
       },
     });
   });
@@ -92,7 +93,7 @@ describe('Universal Schematic', () => {
     const opts = arch.server.options;
     expect(opts.outputPath).toEqual('dist/bar-server');
     expect(opts.main).toEqual('projects/bar/src/main.server.ts');
-    expect(opts.tsConfig).toEqual('projects/bar/tsconfig.server.json');
+    expect(opts.tsConfig).toEqual('projects/bar/src/tsconfig.server.json');
   });
 
   it('should add a server transition to BrowerModule import', () => {

--- a/packages/schematics/angular/universal/schema.json
+++ b/packages/schematics/angular/universal/schema.json
@@ -40,7 +40,7 @@
       "type": "string",
       "format": "path",
       "description": "The name of the application directory.",
-      "default": "src/app"
+      "default": "app"
     },
     "rootModuleFileName": {
       "type": "string",


### PR DESCRIPTION
- Create tsconfig.server.json inside the src/ directory of a project
- Set the `entryModule` to 'app/..' instead of 'src/app/..' to adjust for above
- Set the `baseUrl` in tsconfig.server.json
- Properly set the `main` and `tsConfig` entries in the server section of the config file

Fixes https://github.com/angular/angular-cli/issues/10288