### PR TITLE
fix(@angular/pwa): Set manifest name if no title is provided

### DIFF
--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -39,6 +39,8 @@ export default function (options: PwaOptions): Rule {
 
     const assetPath = join(project.root as Path, 'src', 'assets');
 
+    options.title = options.title || options.project;
+
     const tempalteSource = apply(url('./files/assets'), [
       template({
         ...options,

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -77,4 +77,13 @@ describe('PWA Schematic', () => {
     expect(manifest.name).toEqual(defaultOptions.title);
     expect(manifest.short_name).toEqual(defaultOptions.title);
   });
+
+  it('should set the name & short_name in the manifest file when no title provided', () => {
+    const options = {...defaultOptions, title: undefined};
+    const tree = schematicRunner.runSchematic('ng-add', options, appTree);
+    const manifestText = tree.readContent('/projects/bar/src/assets/manifest.json');
+    const manifest = JSON.parse(manifestText);
+    expect(manifest.name).toEqual(defaultOptions.project);
+    expect(manifest.short_name).toEqual(defaultOptions.project);
+  });
 });


### PR DESCRIPTION
Partially addresses #775