### PR TITLE
fix(@angular-devkit/build-angular): hash files as binary

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/service-worker/index.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/utilities/service-worker/index.ts
@@ -37,21 +37,25 @@ class CliFilesystem implements Filesystem {
   }
 
   read(path: string): Promise<string> {
-    return this._host.read(this._resolve(path))
-      .toPromise()
+    return this._readIntoBuffer(path)
       .then(content => virtualFs.fileBufferToString(content));
   }
 
   hash(path: string): Promise<string> {
     const sha1 = crypto.createHash('sha1');
 
-    return this.read(path)
-      .then(content => sha1.update(content))
+    return this._readIntoBuffer(path)
+      .then(content => sha1.update(Buffer.from(content)))
       .then(() => sha1.digest('hex'));
   }
 
   write(path: string, content: string): Promise<void> {
     return this._host.write(this._resolve(path), virtualFs.stringToFileBuffer(content))
+      .toPromise();
+  }
+
+  private _readIntoBuffer(path: string): Promise<virtualFs.FileBuffer> {
+    return this._host.read(this._resolve(path))
       .toPromise();
   }
 

--- a/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
+++ b/packages/angular_devkit/build_angular/test/browser/service-worker_spec_large.ts
@@ -96,7 +96,7 @@ describe('Browser Builder', () => {
           ],
           dataGroups: [],
           hashTable: {
-            '/favicon.ico': '460fcbd48b20fcc32b184388606af1238c890dba',
+            '/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
             '/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
             '/index.html': '3e659d6e536916b7d178d02a2e6e5492f868bf68',
           },
@@ -151,7 +151,7 @@ describe('Browser Builder', () => {
           ],
           dataGroups: [],
           hashTable: {
-            '/foo/bar/favicon.ico': '460fcbd48b20fcc32b184388606af1238c890dba',
+            '/foo/bar/favicon.ico': '84161b857f5c547e3699ddfbffc6d8d737542e01',
             '/foo/bar/assets/folder-asset.txt': '617f202968a6a81050aa617c2e28e1dca11ce8d4',
             '/foo/bar/index.html': '5b53fa9e07e4111b8ef84613fb989a56fee502b0',
           },


### PR DESCRIPTION
For most files it doesn't make a difference, but for files that are not UTF-8 encoded (such as `*.ico`, `*.png`, etc) converting to string before hashing creates a different digest than what the ServiceWorker
will generate (see [here][1]). This in turn causes the SW to think the config is wrong and enter a degraded state.
This commit ensures that `ngsw.json` will contain hashes computed in the same way as the SW will compute them.

[1]: https://github.com/angular/angular/blob/c8a1a14b87e5907458e8e87021e47f9796cb3257/packages/service-worker/worker/src/assets.ts#L418