### PR TITLE
feat(@schematics/angular): make app installable with `@angular/pwa`

### DIFF
--- a/packages/angular/pwa/pwa/files/assets/manifest.json
+++ b/packages/angular/pwa/pwa/files/assets/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "<%= title %>",
   "theme_color": "#1976d2",
   "background_color": "#fafafa",
-  "display": "browser",
+  "display": "minimal-ui",
   "scope": "/",
   "start_url": "/",
   "icons": [


### PR DESCRIPTION
In order for browsers to prompt the user to install a PWA, the `display` property in `manifest.json` must be one of `minimal-ui`, `standalone`, `fullscreen`. ([Source][1])

Partly addresses angular/angular-cli#10236.

[1]: https://developers.google.com/web/tools/lighthouse/audits/install-prompt