### PR TITLE
fix(@angular/pwa): move manifest and commands where they belong

### DIFF
--- a/packages/angular/pwa/pwa/files/root/manifest.json
+++ b/packages/angular/pwa/pwa/files/root/manifest.json
@@ -8,42 +8,42 @@
   "start_url": "/",
   "icons": [
     {
-      "src": "/assets/icons/icon-72x72.png",
+      "src": "assets/icons/icon-72x72.png",
       "sizes": "72x72",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-96x96.png",
+      "src": "assets/icons/icon-96x96.png",
       "sizes": "96x96",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-128x128.png",
+      "src": "assets/icons/icon-128x128.png",
       "sizes": "128x128",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-144x144.png",
+      "src": "assets/icons/icon-144x144.png",
       "sizes": "144x144",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-152x152.png",
+      "src": "assets/icons/icon-152x152.png",
       "sizes": "152x152",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-192x192.png",
+      "src": "assets/icons/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-384x384.png",
+      "src": "assets/icons/icon-384x384.png",
       "sizes": "384x384",
       "type": "image/png"
     },
     {
-      "src": "/assets/icons/icon-512x512.png",
+      "src": "assets/icons/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -67,12 +67,12 @@ describe('PWA Schematic', () => {
 
   it('should create a manifest file', () => {
     const tree = schematicRunner.runSchematic('ng-add', defaultOptions, appTree);
-    expect(tree.exists('/projects/bar/src/assets/manifest.json')).toEqual(true);
+    expect(tree.exists('/projects/bar/src/manifest.json')).toEqual(true);
   });
 
   it('should set the name & short_name in the manifest file', () => {
     const tree = schematicRunner.runSchematic('ng-add', defaultOptions, appTree);
-    const manifestText = tree.readContent('/projects/bar/src/assets/manifest.json');
+    const manifestText = tree.readContent('/projects/bar/src/manifest.json');
     const manifest = JSON.parse(manifestText);
     expect(manifest.name).toEqual(defaultOptions.title);
     expect(manifest.short_name).toEqual(defaultOptions.title);
@@ -81,9 +81,27 @@ describe('PWA Schematic', () => {
   it('should set the name & short_name in the manifest file when no title provided', () => {
     const options = {...defaultOptions, title: undefined};
     const tree = schematicRunner.runSchematic('ng-add', options, appTree);
-    const manifestText = tree.readContent('/projects/bar/src/assets/manifest.json');
+    const manifestText = tree.readContent('/projects/bar/src/manifest.json');
     const manifest = JSON.parse(manifestText);
     expect(manifest.name).toEqual(defaultOptions.project);
     expect(manifest.short_name).toEqual(defaultOptions.project);
+  });
+
+  it('should update the index file', () => {
+    const tree = schematicRunner.runSchematic('ng-add', defaultOptions, appTree);
+    const content = tree.readContent('projects/bar/src/index.html');
+
+    expect(content).toMatch(/<link rel="manifest" href="manifest.json">/);
+    expect(content).toMatch(/<meta name="theme-color" content="#1976d2">/);
+  });
+
+  it('should update the build and test assets configuration', () => {
+    const tree = schematicRunner.runSchematic('ng-add', defaultOptions, appTree);
+    const configText = tree.readContent('/angular.json');
+    const config = JSON.parse(configText);
+    const architect = config.projects.bar.architect;
+    ['build', 'test'].forEach((target) => {
+      expect(architect[target].options.assets).toContain('projects/bar/src/manifest.json');
+    });
   });
 });

--- a/packages/schematics/angular/service-worker/index.ts
+++ b/packages/schematics/angular/service-worker/index.ts
@@ -18,6 +18,7 @@ import {
   template,
   url,
 } from '@angular-devkit/schematics';
+import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 import * as ts from 'typescript';
 import { addSymbolToNgModuleMetadata, isImported } from '../utility/ast-utils';
 import { InsertChange } from '../utility/change';
@@ -161,69 +162,6 @@ function getTsSourceFile(host: Tree, path: string): ts.SourceFile {
   return source;
 }
 
-function updateIndexFile(options: ServiceWorkerOptions): Rule {
-  return (host: Tree, context: SchematicContext) => {
-    const workspace = getWorkspace(host);
-    const project = workspace.projects[options.project as string];
-    let path: string;
-    if (project && project.architect && project.architect.build &&
-        project.architect.build.options.index) {
-      path = project.architect.build.options.index;
-    } else {
-      throw new SchematicsException('Could not find index file for the project');
-    }
-    const buffer = host.read(path);
-    if (buffer === null) {
-      throw new SchematicsException(`Could not read index file: ${path}`);
-    }
-    const content = buffer.toString();
-    const lines = content.split('\n');
-    let closingHeadTagLineIndex = -1;
-    let closingHeadTagLine = '';
-    lines.forEach((line, index) => {
-      if (/<\/head>/.test(line) && closingHeadTagLineIndex === -1) {
-        closingHeadTagLine = line;
-        closingHeadTagLineIndex = index;
-      }
-    });
-
-    const indent = getIndent(closingHeadTagLine) + '  ';
-    const itemsToAdd = [
-      '<link rel="manifest" href="assets/manifest.json">',
-      '<meta name="theme-color" content="#1976d2">',
-    ];
-
-    const textToInsert = itemsToAdd
-      .map(text => indent + text)
-      .join('\n');
-
-    const updatedIndex = [
-      ...lines.slice(0, closingHeadTagLineIndex),
-      textToInsert,
-      ...lines.slice(closingHeadTagLineIndex),
-    ].join('\n');
-
-    host.overwrite(path, updatedIndex);
-
-    return host;
-  };
-}
-
-function getIndent(text: string): string {
-  let indent = '';
-  let hitNonSpace = false;
-  text.split('')
-    .forEach(char => {
-      if (char === ' ' && !hitNonSpace) {
-        indent += ' ';
-      } else {
-        hitNonSpace = true;
-      }
-    }, 0);
-
-  return indent;
-}
-
 export default function (options: ServiceWorkerOptions): Rule {
   return (host: Tree, context: SchematicContext) => {
     const workspace = getWorkspace(host);
@@ -243,12 +181,13 @@ export default function (options: ServiceWorkerOptions): Rule {
       move(project.root),
     ]);
 
+    context.addTask(new NodePackageInstallTask());
+
     return chain([
       mergeWith(templateSource),
       updateConfigFile(options),
       addDependencies(),
       updateAppModule(options),
-      updateIndexFile(options),
     ])(host, context);
   };
 }

--- a/packages/schematics/angular/service-worker/index_spec.ts
+++ b/packages/schematics/angular/service-worker/index_spec.ts
@@ -96,12 +96,4 @@ describe('Service Worker Schematic', () => {
     const path = '/projects/bar/ngsw-config.json';
     expect(tree.exists(path)).toEqual(true);
   });
-
-  it('should update the index file', () => {
-    const tree = schematicRunner.runSchematic('service-worker', defaultOptions, appTree);
-    const content = tree.readContent('projects/bar/src/index.html');
-
-    expect(content).toMatch(/<link rel="manifest" href="assets\/manifest.json">/);
-    expect(content).toMatch(/<meta name="theme-color" content="#1976d2">/);
-  });
 });


### PR DESCRIPTION
- move addition of `manifest.json` in `ng add @angular/pwa` instead of `ng g service-worker` (fixes angular/angular-cli#10512)

- move `npm install` task in `ng g service-worker` instead of `ng add @angular/pwa` (fixes angular/angular-cli#10332 for `ng g service-worker` too, not just `ng add @angular/pwa`)

- move `manifest.json` to `src` instead of `src/assets` (fixes angular/angular-cli#10511, and probably many other yet unforeseen issues)

@hansl @Brocco @filipesilva 