### PR TITLE
fix(@ngtools/webpack): allow TS 2.4 as peerDep

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 /packages/angular_devkit/core/              @hansl @clydin
 /packages/angular_devkit/schematics/        @hansl @Brocco
 /packages/angular_devkit/schematics_cli/    @hansl @Brocco
-/packages/ngtools/webpack/                  @hansl @Brocco
+/packages/ngtools/webpack/                  @hansl @filipesilva @clydin
 /packages/schematics/angular/               @hansl @Brocco
 /packages/schematics/package_update/        @hansl @Brocco
 /packages/schematics/schematics/            @hansl @Brocco

--- a/packages/ngtools/webpack/package.json
+++ b/packages/ngtools/webpack/package.json
@@ -30,7 +30,7 @@
     "webpack-sources": "^1.1.0"
   },
   "peerDependencies": {
-    "typescript": "~2.5.0 || ~2.6.0 || ~2.7.0",
+    "typescript": "~2.4.0 || ~2.5.0 || ~2.6.0 || ~2.7.0",
     "webpack": "^4.0.0"
   }
 }


### PR DESCRIPTION
This allows the plugin to be used in Angular 5 projects without peerDep warnings.