### PR TITLE
fix(@angular-devkit/build-optimizer): match comments in enums

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -10,13 +10,29 @@ import { drilldownNodes } from '../helpers/ast-utils';
 
 
 export function testWrapEnums(content: string) {
+  const ts22EnumVarDecl = /var (\S+) = \{\};/;
+  // tslint:disable-next-line:max-line-length
+  const ts22EnumIife = /(\1\.(\S+) = \d+;\r?\n)+\1\[\1\.(\S+)\] = "\4";\r?\n(\1\[\1\.(\S+)\] = "\S+";\r?\n*)+/;
+  const ts23To26VarDecl = /var (\S+);(\/\*@__PURE__\*\/)*/;
+  // tslint:disable-next-line:max-line-length
+  const ts23To26Iife = /\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = (\S+)\] = "\4";(\s+\1\[\1\["\S+"\] = (\S+)\] = "\S+";)*\r?\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/;
+  const enumComment = /\/\*\* @enum \{\w+\} \*\//;
+  const multiLineComment = /\s*(?:\/\*[\s\S]*?\*\/)?\s*/;
+  const newLine = /\s*\r?\n\s*/;
+
   const regexes = [
-    // tslint:disable:max-line-length
-    /var (\S+) = \{\};\r?\n(\1\.(\S+) = \d+;\r?\n)+\1\[\1\.(\S+)\] = "\4";\r?\n(\1\[\1\.(\S+)\] = "\S+";\r?\n*)+/,
-    /var (\S+);(\/\*@__PURE__\*\/)*\r?\n\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = (\S+)\] = "\4";(\s+\1\[\1\["\S+"\] = (\S+)\] = "\S+";)*\r?\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/,
-    /\/\*\* @enum \{\w+\} \*\//,
-  // tslint:enable:max-line-length
-  ];
+    [
+      ts22EnumVarDecl,
+      newLine, multiLineComment,
+      ts22EnumIife,
+    ],
+    [
+      ts23To26VarDecl,
+      newLine, multiLineComment,
+      ts23To26Iife,
+    ],
+    [enumComment],
+  ].map(arr => new RegExp(arr.map(x => x.source).join(''), 'm'));
 
   return regexes.some((regex) => regex.test(content));
 }

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums_spec.ts
@@ -115,4 +115,54 @@ describe('wrap-enums', () => {
     expect(testWrapEnums(input)).toBeTruthy();
     expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
   });
+
+  it('wraps enums with multi-line comments in IIFE', () => {
+    const input = tags.stripIndent`
+      /**
+       * Supported http methods.
+       * @deprecated use @angular/common/http instead
+       */
+      var RequestMethod;
+      /**
+       * Supported http methods.
+       * @deprecated use @angular/common/http instead
+       */
+      (function (RequestMethod) {
+          RequestMethod[RequestMethod["Get"] = 0] = "Get";
+          RequestMethod[RequestMethod["Post"] = 1] = "Post";
+          RequestMethod[RequestMethod["Put"] = 2] = "Put";
+          RequestMethod[RequestMethod["Delete"] = 3] = "Delete";
+          RequestMethod[RequestMethod["Options"] = 4] = "Options";
+          RequestMethod[RequestMethod["Head"] = 5] = "Head";
+          RequestMethod[RequestMethod["Patch"] = 6] = "Patch";
+      })(RequestMethod || (RequestMethod = {}));
+    `;
+    // We need to interpolate this space because our editorconfig automatically strips
+    // trailing whitespace.
+    const space = ' ';
+    const output = tags.stripIndent`
+      /**
+       * Supported http methods.
+       * @deprecated use @angular/common/http instead
+       */
+      var RequestMethod =${space}
+       /**
+       * Supported http methods.
+       * @deprecated use @angular/common/http instead
+       */
+      /*@__PURE__*/ (function (RequestMethod) {
+          RequestMethod[RequestMethod["Get"] = 0] = "Get";
+          RequestMethod[RequestMethod["Post"] = 1] = "Post";
+          RequestMethod[RequestMethod["Put"] = 2] = "Put";
+          RequestMethod[RequestMethod["Delete"] = 3] = "Delete";
+          RequestMethod[RequestMethod["Options"] = 4] = "Options";
+          RequestMethod[RequestMethod["Head"] = 5] = "Head";
+          RequestMethod[RequestMethod["Patch"] = 6] = "Patch";
+          return RequestMethod;
+      })({});
+    `;
+
+    expect(testWrapEnums(input)).toBeTruthy();
+    expect(tags.oneLine`${transform(input)}`).toEqual(tags.oneLine`${output}`);
+  });
 });


### PR DESCRIPTION
Big thanks to @clydin for investigation, reproduction and test.

Fix https://github.com/angular/devkit/issues/831