### PR TITLE
fix(@angular-devkit/build-optimizer): remove enum regexes

### DIFF
--- a/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
+++ b/packages/angular_devkit/build_optimizer/src/build-optimizer/build-optimizer_spec.ts
@@ -189,7 +189,9 @@ describe('build-optimizer', () => {
       ).sourceMap).toBeTruthy();
     });
 
-    it('doesn\'t produce sourcemaps when emitting was skipped', () => {
+    // TODO: re-enable this test, it was temporarily disabled as part of
+    // https://github.com/angular/devkit/pull/842
+    xit('doesn\'t produce sourcemaps when emitting was skipped', () => {
       const ignoredInput = tags.oneLine`
         var Clazz = (function () { function Clazz() { } return Clazz; }());
         ${staticProperty}

--- a/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
+++ b/packages/angular_devkit/build_optimizer/src/transforms/wrap-enums.ts
@@ -10,31 +10,8 @@ import { drilldownNodes } from '../helpers/ast-utils';
 
 
 export function testWrapEnums(content: string) {
-  const ts22EnumVarDecl = /var (\S+) = \{\};/;
-  // tslint:disable-next-line:max-line-length
-  const ts22EnumIife = /(\1\.(\S+) = \d+;\r?\n)+\1\[\1\.(\S+)\] = "\4";\r?\n(\1\[\1\.(\S+)\] = "\S+";\r?\n*)+/;
-  const ts23To26VarDecl = /var (\S+);(\/\*@__PURE__\*\/)*/;
-  // tslint:disable-next-line:max-line-length
-  const ts23To26Iife = /\(function \(\1\) \{\s+(\1\[\1\["(\S+)"\] = (\S+)\] = "\4";(\s+\1\[\1\["\S+"\] = (\S+)\] = "\S+";)*\r?\n)\}\)\(\1 \|\| \(\1 = \{\}\)\);/;
-  const enumComment = /\/\*\* @enum \{\w+\} \*\//;
-  const multiLineComment = /\s*(?:\/\*[\s\S]*?\*\/)?\s*/;
-  const newLine = /\s*\r?\n\s*/;
-
-  const regexes = [
-    [
-      ts22EnumVarDecl,
-      newLine, multiLineComment,
-      ts22EnumIife,
-    ],
-    [
-      ts23To26VarDecl,
-      newLine, multiLineComment,
-      ts23To26Iife,
-    ],
-    [enumComment],
-  ].map(arr => new RegExp(arr.map(x => x.source).join(''), 'm'));
-
-  return regexes.some((regex) => regex.test(content));
+  // TODO: remove this method, it's not doing anything anymore.
+  return true;
 }
 
 function isBlockLike(node: ts.Node): node is ts.BlockLike {


### PR DESCRIPTION
They were computationally expensive and returning false negatives.

Fix https://github.com/angular/angular-cli/issues/10605