### PR TITLE
fix(@angular-devkit/build-angular): remove mangle and compress from server build

### DIFF
--- a/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
+++ b/packages/angular_devkit/build_angular/src/angular-cli-files/models/webpack-configs/common.ts
@@ -200,6 +200,32 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
     alias = rxPaths(nodeModules);
   } catch (e) { }
 
+  const uglifyOptions = {
+    ecma: wco.supportES2015 ? 6 : 5,
+    warnings: !!buildOptions.verbose,
+    safari10: true,
+    output: {
+      ascii_only: true,
+      comments: false,
+      webkit: true,
+    },
+
+    // On server, we don't want to compress anything.
+    ...(buildOptions.platform == 'server' ? {} : {
+      compress: {
+        pure_getters: buildOptions.buildOptimizer,
+        // PURE comments work best with 3 passes.
+        // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
+        passes: buildOptions.buildOptimizer ? 3 : 1,
+        // Workaround known uglify-es issue
+        // See https://github.com/mishoo/UglifyJS2/issues/2949#issuecomment-368070307
+        inline: wco.supportES2015 ? 1 : 3,
+      }
+    }),
+    // We also want to avoid mangling on server.
+    ...(buildOptions.platform == 'server' ? { mangle: false } : {})
+  };
+
   return {
     mode: buildOptions.optimization ? 'production' : 'development',
     devtool: false,
@@ -271,25 +297,7 @@ export function getCommonConfig(wco: WebpackConfigOptions) {
           sourceMap: buildOptions.sourceMap,
           parallel: true,
           cache: true,
-          uglifyOptions: {
-            ecma: wco.supportES2015 ? 6 : 5,
-            warnings: buildOptions.verbose,
-            safari10: true,
-            compress: {
-              pure_getters: buildOptions.buildOptimizer,
-              // PURE comments work best with 3 passes.
-              // See https://github.com/webpack/webpack/issues/2899#issuecomment-317425926.
-              passes: buildOptions.buildOptimizer ? 3 : 1,
-              // Workaround known uglify-es issue
-              // See https://github.com/mishoo/UglifyJS2/issues/2949#issuecomment-368070307
-              inline: wco.supportES2015 ? 1 : 3,
-            },
-            output: {
-              ascii_only: true,
-              comments: false,
-              webkit: true,
-            },
-          }
+          uglifyOptions,
         }),
       ],
     },

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -54,19 +54,10 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
       concatMap(() => options.deleteOutputPath
         ? this._deleteOutputDir(root, normalize(options.outputPath), this.context.host)
         : of(null)),
-        concatMap(() => addFileReplacements(root, host, options.fileReplacements)),
-        concatMap(() => new Observable(obs => {
+      concatMap(() => addFileReplacements(root, host, options.fileReplacements)),
+      concatMap(() => new Observable(obs => {
         // Ensure Build Optimizer is only used with AOT.
-        let webpackConfig;
-        try {
-          webpackConfig = this.buildWebpackConfig(root, projectRoot, host, options);
-        } catch (e) {
-          // TODO: why do I have to catch this error? I thought throwing inside an observable
-          // always got converted into an error.
-          obs.error(e);
-
-          return;
-        }
+        const webpackConfig = this.buildWebpackConfig(root, projectRoot, host, options);
         const webpackCompiler = webpack(webpackConfig);
         const statsConfig = getWebpackStatsConfig(options.verbose);
 
@@ -132,6 +123,7 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
       // TODO: use only this.options, it contains all flags and configs items already.
       buildOptions: {
         ...buildOptions,
+        buildOptimizer: false,
         aot: true,
         platform: 'server',
         scripts: [],


### PR DESCRIPTION
Using those for server might break the runtime, and since it all runs on the server
we dont need to compress, local name mangling works fine. Also remove the build
optimizer pass on server optimized builds.

Partial fix for angular/angular-cli#8616 (need to have a fix for 1.7.x)