### PR TITLE
feat(@angular/pwa): add content for when javascript is not available

### DIFF
--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -66,27 +66,41 @@ function updateIndexFile(options: PwaOptions): Rule {
     const lines = content.split('\n');
     let closingHeadTagLineIndex = -1;
     let closingHeadTagLine = '';
-    lines.forEach((line, index) => {
+    let closingBodyTagLineIndex = -1;
+    let closingBodyTagLine = '';
+    lines.forEach((line: string, index: number) => {
       if (/<\/head>/.test(line) && closingHeadTagLineIndex === -1) {
         closingHeadTagLine = line;
         closingHeadTagLineIndex = index;
       }
+
+      if (/<\/body>/.test(line) && closingBodyTagLineIndex === -1) {
+        closingBodyTagLine = line;
+        closingBodyTagLineIndex = index;
+      }
     });
 
-    const indent = getIndent(closingHeadTagLine) + '  ';
-    const itemsToAdd = [
+    const headTagIndent = getIndent(closingHeadTagLine) + '  ';
+    const itemsToAddToHead = [
       '<link rel="manifest" href="manifest.json">',
       '<meta name="theme-color" content="#1976d2">',
     ];
 
-    const textToInsert = itemsToAdd
-      .map(text => indent + text)
+    const textToInsertIntoHead = itemsToAddToHead
+      .map(text => headTagIndent + text)
       .join('\n');
+
+    const bodyTagIndent = getIndent(closingBodyTagLine) + '  ';
+    const itemsToAddToBody = '<noscript>Please enable Javascript to continue using this application.</noscript>'
+
+    const textToInsertIntoBody = bodyTagIndent + itemsToAddToBody;
 
     const updatedIndex = [
       ...lines.slice(0, closingHeadTagLineIndex),
-      textToInsert,
-      ...lines.slice(closingHeadTagLineIndex),
+      textToInsertIntoHead,
+      ...lines.slice(closingHeadTagLineIndex, closingBodyTagLineIndex),
+      textToInsertIntoBody,
+      ...lines.slice(closingBodyTagLineIndex),
     ].join('\n');
 
     host.overwrite(path, updatedIndex);

--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -91,7 +91,8 @@ function updateIndexFile(options: PwaOptions): Rule {
       .join('\n');
 
     const bodyTagIndent = getIndent(closingBodyTagLine) + '  ';
-    const itemsToAddToBody = '<noscript>Please enable Javascript to continue using this application.</noscript>'
+    const itemsToAddToBody
+      = '<noscript>Please enable Javascript to continue using this application.</noscript>';
 
     const textToInsertIntoBody = bodyTagIndent + itemsToAddToBody;
 

--- a/packages/angular/pwa/pwa/index.ts
+++ b/packages/angular/pwa/pwa/index.ts
@@ -92,7 +92,7 @@ function updateIndexFile(options: PwaOptions): Rule {
 
     const bodyTagIndent = getIndent(closingBodyTagLine) + '  ';
     const itemsToAddToBody
-      = '<noscript>Please enable Javascript to continue using this application.</noscript>';
+      = '<noscript>Please enable JavaScript to continue using this application.</noscript>';
 
     const textToInsertIntoBody = bodyTagIndent + itemsToAddToBody;
 

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -93,6 +93,7 @@ describe('PWA Schematic', () => {
 
     expect(content).toMatch(/<link rel="manifest" href="manifest.json">/);
     expect(content).toMatch(/<meta name="theme-color" content="#1976d2">/);
+    expect(content).toMatch(/<noscript>Please enable Javascript to continue using this application.<\/noscript>/);
   });
 
   it('should update the build and test assets configuration', () => {

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -93,7 +93,8 @@ describe('PWA Schematic', () => {
 
     expect(content).toMatch(/<link rel="manifest" href="manifest.json">/);
     expect(content).toMatch(/<meta name="theme-color" content="#1976d2">/);
-    expect(content).toMatch(/<noscript>Please enable Javascript to continue using this application.<\/noscript>/);
+    expect(content)
+      .toMatch(/<noscript>Please enable Javascript to continue using this application.<\/noscript>/);
   });
 
   it('should update the build and test assets configuration', () => {

--- a/packages/angular/pwa/pwa/index_spec.ts
+++ b/packages/angular/pwa/pwa/index_spec.ts
@@ -94,7 +94,7 @@ describe('PWA Schematic', () => {
     expect(content).toMatch(/<link rel="manifest" href="manifest.json">/);
     expect(content).toMatch(/<meta name="theme-color" content="#1976d2">/);
     expect(content)
-      .toMatch(/<noscript>Please enable Javascript to continue using this application.<\/noscript>/);
+      .toMatch(/<noscript>Please enable JavaScript to continue using this application.<\/noscript>/);
   });
 
   it('should update the build and test assets configuration', () => {


### PR DESCRIPTION
Adding this line to the body will give us a 100 score in lighthouse for PWA.
![image](https://user-images.githubusercontent.com/9759954/39659076-8fad4a96-4fee-11e8-9d26-3da5b7bbb59a.png)
Hosted site (with added `<noscript>` tag): https://angular-cli-pwa.firebaseapp.com/

Thanks so much to @Brocco for providing a great example to follow for manipulating the html file. A few of the updates are to make the variable names more semantic given the similar usage.