### PR TITLE
fix(@schematics/angular): fix e2e schematic to expect welcome message with prefix

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -275,6 +275,7 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
+      prefix,
     };
     if (options.projectRoot !== undefined) {
       e2eOptions.projectRoot = 'e2e';

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
@@ -9,6 +9,6 @@ describe('workspace-project App', () => {
 
   it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('Welcome to app!');
+    expect(page.getParagraphText()).toEqual('Welcome to <%= prefix %>!');
   });
 });

--- a/packages/schematics/angular/e2e/schema.d.ts
+++ b/packages/schematics/angular/e2e/schema.d.ts
@@ -23,4 +23,8 @@ export interface Schema {
      * The name of the app being tested.
      */
     relatedAppName: string;
+    /**
+     * The prefix to apply to generated selectors.
+     */
+    prefix?: string;
 }

--- a/packages/schematics/angular/e2e/schema.json
+++ b/packages/schematics/angular/e2e/schema.json
@@ -23,6 +23,12 @@
       "type": "string",
       "default": "app-root"
     },
+    "prefix": {
+      "type": "string",
+      "format": "html-selector",
+      "description": "The prefix to apply to generated selectors.",
+      "default": "app"
+    },
     "relatedAppName": {
       "description": "The name of the app being tested.",
       "type": "string"


### PR DESCRIPTION
The "application" schematic generates the welcome message in AppComponent with the app prefix.
The "e2e" schematic did not include the prefix in the spec file accordingly.

This PR includes the app prefix in the welcome message spec.
Thanks for reviewing this!