### PR TITLE
fix(@angular-devkit/build-angular): allow customization of webpack co…

### DIFF
--- a/packages/angular_devkit/architect/src/architect.ts
+++ b/packages/angular_devkit/architect/src/architect.ts
@@ -72,6 +72,7 @@ export interface BuilderConfiguration<OptionsT = {}> {
   root: Path;
   sourceRoot?: Path;
   projectType: string;
+  target: string;
   builder: string;
   options: OptionsT;
 }
@@ -192,6 +193,7 @@ export class Architect {
       root: project.root as Path,
       sourceRoot: project.sourceRoot as Path | undefined,
       projectType: project.projectType,
+      target: targetName,
       builder: target.builder,
       options: {
         ...options,

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -202,7 +202,7 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
         normalize(options.webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config, target: string) = require(webpackConfigPath);
+          const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -197,9 +197,11 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
 
     let mergedConfig = webpackMerge(webpackConfigs);
 
-    if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root,
-        normalize(options.webpackConfig))));
+    const customWebpackConfigs: string[] = Array.isArray(options.webpackConfig) ?
+      options.webpackConfig : ('string' === typeof options.webpackConfig ?
+        [options.webpackConfig] : []);
+    customWebpackConfigs.forEach((webpackConfig: string): void => {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
           const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
@@ -207,10 +209,11 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
             mergedConfig = callback(mergedConfig, target);
           }
         } catch (error) {
-          throw new Error('Failed to merge custom webpack configuration: ' + error);
+          throw new Error(`Failed to merge custom webpack configuration by script ` +
+            `"${webpackConfig}": ${error}`);
         }
       }
-    }
+    });
 
     return mergedConfig;
   }

--- a/packages/angular_devkit/build_angular/src/browser/index.ts
+++ b/packages/angular_devkit/build_angular/src/browser/index.ts
@@ -67,8 +67,8 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
       concatMap(() => normalizeAssetPatterns(
         options.assets, host, root, projectRoot, builderConfig.sourceRoot)),
       // Replace the assets in options with the normalized version.
-      tap(((assetPatternObjects: any) => options.assets = assetPatternObjects)),
-      concatMap(() => new Observable((obs: any) => {
+      tap((assetPatternObjects => options.assets = assetPatternObjects)),
+      concatMap(() => new Observable(obs => {
         // Ensure Build Optimizer is only used with AOT.
         if (options.buildOptimizer && !options.aot) {
           throw new Error('The `--build-optimizer` option cannot be used without `--aot`.');
@@ -76,7 +76,8 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
 
         let webpackConfig;
         try {
-          webpackConfig = this.buildWebpackConfig(root, projectRoot, host, builderConfig.target, options as NormalizedBrowserBuilderSchema);
+          webpackConfig = this.buildWebpackConfig(root, projectRoot, host, builderConfig.target,
+            options as NormalizedBrowserBuilderSchema);
         } catch (e) {
           obs.error(e);
 
@@ -85,7 +86,7 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
         const webpackCompiler = webpack(webpackConfig);
         const statsConfig = getWebpackStatsConfig(options.verbose);
 
-        const callback: webpack.compiler.CompilerCallback = (err: any, stats: any) => {
+        const callback: webpack.compiler.CompilerCallback = (err, stats) => {
           if (err) {
             return obs.error(err);
           }
@@ -194,18 +195,18 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
       webpackConfigs.push(typescriptConfigPartial);
     }
 
-    let mergedConfig: any = webpackMerge(webpackConfigs);
+    let mergedConfig = webpackMerge(webpackConfigs);
 
     if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(options.webpackConfig))));
-      if(fs.existsSync(webpackConfigPath)) {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root,
+        normalize(options.webpackConfig))));
+      if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config: {[key: string]: any}, target: string) => {[key: string]: any} = require(webpackConfigPath);
+          const callback: (config, target: string) = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }
-        }
-        catch(error) {
+        } catch (error) {
           throw new Error('Failed to merge custom webpack configuration: ' + error);
         }
       }
@@ -221,7 +222,7 @@ export class BrowserBuilder implements Builder<BrowserBuilderSchema> {
     }
 
     return host.exists(resolvedOutputPath).pipe(
-      concatMap((exists: any) => exists
+      concatMap(exists => exists
         // TODO: remove this concat once host ops emit an event.
         ? concat(host.delete(resolvedOutputPath), of(null)).pipe(last())
         // ? of(null)

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -219,9 +219,9 @@ export interface BrowserBuilderSchema {
   budgets: Budget[];
 
   /**
-   * Script path containing a method to modify the webpack config with customizations
+   * Script path(s) containing a method to modify the webpack config with customizations
    */
-  webpackConfig: string;
+  webpackConfig: string[] | string;
 }
 
 export type AssetPattern = string | AssetPatternObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -217,6 +217,11 @@ export interface BrowserBuilderSchema {
    * Budget thresholds to ensure parts of your application stay within boundaries which you set.
    */
   budgets: Budget[];
+
+  /**
+   * Script path containing a method to modify the webpack config with customizations
+   */
+  webpackConfig: string;
 }
 
 export type AssetPattern = string | AssetPatternObject;

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -232,6 +232,10 @@
         "$ref": "#/definitions/budget"
       },
       "default": []
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Script path containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/browser/schema.json
+++ b/packages/angular_devkit/build_angular/src/browser/schema.json
@@ -234,8 +234,19 @@
       "default": []
     },
     "webpackConfig": {
-      "type": "string",
-      "description": "Script path containing custom webpack config"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": [],
+      "description": "Script path(s) containing a method to modify the webpack config with customizations"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -103,17 +103,18 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     let browserOptions: BrowserBuilderSchema;
 
     return checkPort(options.port, options.host).pipe(
-      tap((port: any) => options.port = port),
+      tap(port => options.port = port),
       concatMap(() => this._getBrowserOptions(options)),
-      tap((opts: any) => browserOptions = opts),
+      tap(opts => browserOptions = opts),
       concatMap(() => addFileReplacements(root, host, browserOptions.fileReplacements)),
       concatMap(() => normalizeAssetPatterns(
         browserOptions.assets, host, root, projectRoot, builderConfig.sourceRoot)),
       // Replace the assets in options with the normalized version.
-      tap(((assetPatternObjects: any) => browserOptions.assets = assetPatternObjects)),
-      concatMap(() => new Observable((obs: any) => {
+      tap((assetPatternObjects => browserOptions.assets = assetPatternObjects)),
+      concatMap(() => new Observable(obs => {
         const browserBuilder = new BrowserBuilder(this.context);
-        const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, host, builderConfig.target, browserOptions as NormalizedBrowserBuilderSchema);
+        const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, host,
+          builderConfig.target, browserOptions as NormalizedBrowserBuilderSchema);
         const statsConfig = getWebpackStatsConfig(browserOptions.verbose);
 
         let webpackDevServerConfig: WebpackDevServerConfigurationOptions;
@@ -296,8 +297,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     let webpackDevServerPath;
     try {
       webpackDevServerPath = require.resolve('webpack-dev-server/client');
-    }
-    catch(error) {
+    } catch (error) {
       throw new Error('The "webpack-dev-server" package could not be found.');
     }
     const entryPoints = [`${webpackDevServerPath}?${clientAddress}`];
@@ -461,9 +461,9 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     };
 
     return architect.getBuilderDescription(builderConfig).pipe(
-      concatMap((browserDescription: any) =>
+      concatMap(browserDescription =>
         architect.validateBuilderOptions(builderConfig, browserDescription)),
-      map((browserConfig: any) => browserConfig.options),
+      map(browserConfig => browserConfig.options),
     );
   }
 }

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -62,6 +62,7 @@ export interface DevServerBuilderOptions {
   baseHref?: string;
   progress?: boolean;
   poll?: number;
+  webpackConfig?: string;
 }
 
 interface WebpackDevServerConfigurationOptions {
@@ -102,18 +103,17 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     let browserOptions: BrowserBuilderSchema;
 
     return checkPort(options.port, options.host).pipe(
-      tap((port) => options.port = port),
+      tap((port: any) => options.port = port),
       concatMap(() => this._getBrowserOptions(options)),
-      tap((opts) => browserOptions = opts),
+      tap((opts: any) => browserOptions = opts),
       concatMap(() => addFileReplacements(root, host, browserOptions.fileReplacements)),
       concatMap(() => normalizeAssetPatterns(
         browserOptions.assets, host, root, projectRoot, builderConfig.sourceRoot)),
       // Replace the assets in options with the normalized version.
-      tap((assetPatternObjects => browserOptions.assets = assetPatternObjects)),
-      concatMap(() => new Observable(obs => {
+      tap(((assetPatternObjects: any) => browserOptions.assets = assetPatternObjects)),
+      concatMap(() => new Observable((obs: any) => {
         const browserBuilder = new BrowserBuilder(this.context);
-        const webpackConfig = browserBuilder.buildWebpackConfig(
-          root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
+        const webpackConfig = browserBuilder.buildWebpackConfig(root, projectRoot, host, builderConfig.target, browserOptions as NormalizedBrowserBuilderSchema);
         const statsConfig = getWebpackStatsConfig(browserOptions.verbose);
 
         let webpackDevServerConfig: WebpackDevServerConfigurationOptions;
@@ -296,7 +296,8 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
     let webpackDevServerPath;
     try {
       webpackDevServerPath = require.resolve('webpack-dev-server/client');
-    } catch {
+    }
+    catch(error) {
       throw new Error('The "webpack-dev-server" package could not be found.');
     }
     const entryPoints = [`${webpackDevServerPath}?${clientAddress}`];
@@ -455,12 +456,14 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       ...(options.poll !== undefined ? { poll: options.poll } : {}),
 
       ...builderConfig.options,
+
+      ...(options.webpackConfig !== undefined ? { webpackConfig: options.webpackConfig } : {}),
     };
 
     return architect.getBuilderDescription(builderConfig).pipe(
-      concatMap(browserDescription =>
+      concatMap((browserDescription: any) =>
         architect.validateBuilderOptions(builderConfig, browserDescription)),
-      map(browserConfig => browserConfig.options),
+      map((browserConfig: any) => browserConfig.options),
     );
   }
 }

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -121,6 +121,10 @@
     "poll": {
       "type": "number",
       "description": "Enable and define the file watching poll time period in milliseconds."
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Script path containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/dev-server/schema.json
+++ b/packages/angular_devkit/build_angular/src/dev-server/schema.json
@@ -123,8 +123,19 @@
       "description": "Enable and define the file watching poll time period in milliseconds."
     },
     "webpackConfig": {
-      "type": "string",
-      "description": "Script path containing custom webpack config"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": [],
+      "description": "Script path(s) containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -151,9 +151,11 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
 
     let mergedConfig = webpackMerge(webpackConfigs);
 
-    if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root,
-        normalize(options.webpackConfig))));
+    const customWebpackConfigs: string[] = Array.isArray(options.webpackConfig) ?
+      options.webpackConfig : ('string' === typeof options.webpackConfig ?
+        [options.webpackConfig] : []);
+    customWebpackConfigs.forEach((webpackConfig: string): void => {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
           const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
@@ -161,10 +163,11 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
             mergedConfig = callback(mergedConfig, target);
           }
         } catch (error) {
-          throw new Error('Failed to merge custom webpack configuration: ' + error);
+          throw new Error(`Failed to merge custom webpack configuration by script ` +
+            `"${webpackConfig}": ${error}`);
         }
       }
-    }
+    });
 
     return mergedConfig;
   }

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -156,7 +156,7 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
         normalize(options.webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config, target: string) = require(webpackConfigPath);
+          const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }

--- a/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/index.ts
@@ -149,18 +149,18 @@ export class ExtractI18nBuilder implements Builder<ExtractI18nBuilderOptions> {
       getStylesConfig(wco),
     ];
 
-    let mergedConfig: any = webpackMerge(webpackConfigs);
+    let mergedConfig = webpackMerge(webpackConfigs);
 
     if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(options.webpackConfig))));
-      if(fs.existsSync(webpackConfigPath)) {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root,
+        normalize(options.webpackConfig))));
+      if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config: {[key: string]: any}, target: string) => {[key: string]: any} = require(webpackConfigPath);
+          const callback: (config, target: string) = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }
-        }
-        catch(error) {
+        } catch (error) {
           throw new Error('Failed to merge custom webpack configuration: ' + error);
         }
       }

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -33,8 +33,19 @@
       "description": "Name of the file to output."
     },
     "webpackConfig": {
-      "type": "string",
-      "description": "Script path containing custom webpack config"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": [],
+      "description": "Script path(s) containing a method to modify the webpack config with customizations"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
+++ b/packages/angular_devkit/build_angular/src/extract-i18n/schema.json
@@ -31,6 +31,10 @@
     "outFile": {
       "type": "string",
       "description": "Name of the file to output."
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Script path containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -146,9 +146,11 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
 
     let mergedConfig = webpackMerge(webpackConfigs);
 
-    if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root,
-        normalize(options.webpackConfig))));
+    const customWebpackConfigs: string[] = Array.isArray(options.webpackConfig) ?
+      options.webpackConfig : ('string' === typeof options.webpackConfig ?
+        [options.webpackConfig] : []);
+    customWebpackConfigs.forEach((webpackConfig: string): void => {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
           const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
@@ -156,10 +158,11 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
             mergedConfig = callback(mergedConfig, target);
           }
         } catch (error) {
-          throw new Error('Failed to merge custom webpack configuration: ' + error);
+          throw new Error(`Failed to merge custom webpack configuration by script ` +
+            `"${webpackConfig}": ${error}`);
         }
       }
-    }
+    });
 
     return mergedConfig;
   }

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -151,7 +151,7 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
         normalize(options.webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config, target: string) = require(webpackConfigPath);
+          const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }

--- a/packages/angular_devkit/build_angular/src/karma/index.ts
+++ b/packages/angular_devkit/build_angular/src/karma/index.ts
@@ -144,18 +144,18 @@ export class KarmaBuilder implements Builder<KarmaBuilderSchema> {
       getTestConfig(wco),
     ];
 
-    let mergedConfig: any = webpackMerge(webpackConfigs);
+    let mergedConfig = webpackMerge(webpackConfigs);
 
     if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(options.webpackConfig))));
-      if(fs.existsSync(webpackConfigPath)) {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root,
+        normalize(options.webpackConfig))));
+      if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config: {[key: string]: any}, target: string) => {[key: string]: any} = require(webpackConfigPath);
+          const callback: (config, target: string) = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }
-        }
-        catch(error) {
+        } catch (error) {
           throw new Error('Failed to merge custom webpack configuration: ' + error);
         }
       }

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -32,4 +32,9 @@ export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
    * Globs to exclude from code coverage.
    */
   codeCoverageExclude: string[];
+
+  /**
+   * Script path containing a method to modify the webpack config with customizations
+   */
+  webpackConfig: string;
 }

--- a/packages/angular_devkit/build_angular/src/karma/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/karma/schema.d.ts
@@ -34,7 +34,7 @@ export interface KarmaBuilderSchema extends Pick<BrowserBuilderSchema,
   codeCoverageExclude: string[];
 
   /**
-   * Script path containing a method to modify the webpack config with customizations
+   * Script path(s) containing a method to modify the webpack config with customizations
    */
-  webpackConfig: string;
+  webpackConfig: string[] | string;
 }

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -142,6 +142,10 @@
         ]
       },
       "default": []
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Script path containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/karma/schema.json
+++ b/packages/angular_devkit/build_angular/src/karma/schema.json
@@ -144,8 +144,19 @@
       "default": []
     },
     "webpackConfig": {
-      "type": "string",
-      "description": "Script path containing custom webpack config"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": [],
+      "description": "Script path(s) containing a method to modify the webpack config with customizations"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -12,8 +12,8 @@ import {
   BuilderConfiguration,
   BuilderContext,
 } from '@angular-devkit/architect';
-import * as fs from 'fs';
 import { Path, getSystemPath, normalize, resolve, virtualFs } from '@angular-devkit/core';
+import * as fs from 'fs';
 import { Stats } from 'fs';
 import { Observable, concat, of } from 'rxjs';
 import { concatMap, last } from 'rxjs/operators';
@@ -60,7 +60,8 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
         // Ensure Build Optimizer is only used with AOT.
         let webpackConfig;
         try {
-          webpackConfig = this.buildWebpackConfig(root, projectRoot, host, builderConfig.target, options);
+          webpackConfig = this.buildWebpackConfig(root, projectRoot, host,
+            builderConfig.target, options);
         } catch (e) {
           // TODO: why do I have to catch this error? I thought throwing inside an observable
           // always got converted into an error.
@@ -157,18 +158,18 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
       webpackConfigs.push(typescriptConfigPartial);
     }
 
-    let mergedConfig: any = webpackMerge(webpackConfigs);
+    let mergedConfig = webpackMerge(webpackConfigs);
 
     if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(options.webpackConfig))));
-      if(fs.existsSync(webpackConfigPath)) {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root,
+        normalize(options.webpackConfig))));
+      if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config: {[key: string]: any}, target: string) => {[key: string]: any} = require(webpackConfigPath);
+          const callback: (config, target: string) = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }
-        }
-        catch(error) {
+        } catch (error) {
           throw new Error('Failed to merge custom webpack configuration: ' + error);
         }
       }

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -165,7 +165,7 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
         normalize(options.webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
-          const callback: (config, target: string) = require(webpackConfigPath);
+          const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
           if ('function' === typeof callback) {
             mergedConfig = callback(mergedConfig, target);
           }

--- a/packages/angular_devkit/build_angular/src/server/index.ts
+++ b/packages/angular_devkit/build_angular/src/server/index.ts
@@ -160,9 +160,11 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
 
     let mergedConfig = webpackMerge(webpackConfigs);
 
-    if ('string' === typeof options.webpackConfig) {
-      const webpackConfigPath = getSystemPath(normalize(resolve(root,
-        normalize(options.webpackConfig))));
+    const customWebpackConfigs: string[] = Array.isArray(options.webpackConfig) ?
+      options.webpackConfig : ('string' === typeof options.webpackConfig ?
+        [options.webpackConfig] : []);
+    customWebpackConfigs.forEach((webpackConfig: string): void => {
+      const webpackConfigPath = getSystemPath(normalize(resolve(root, normalize(webpackConfig))));
       if (fs.existsSync(webpackConfigPath)) {
         try {
           const callback: (config: Object, target: string) => Object = require(webpackConfigPath);
@@ -170,10 +172,11 @@ export class ServerBuilder implements Builder<BuildWebpackServerSchema> {
             mergedConfig = callback(mergedConfig, target);
           }
         } catch (error) {
-          throw new Error('Failed to merge custom webpack configuration: ' + error);
+          throw new Error(`Failed to merge custom webpack configuration by script ` +
+            `"${webpackConfig}": ${error}`);
         }
       }
-    }
+    });
 
     return mergedConfig;
   }

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -114,9 +114,9 @@ export interface BuildWebpackServerSchema {
    */
   namedChunks?: boolean;
   /**
-   * Script path containing a method to modify the webpack config with customizations
+   * Script path(s) containing a method to modify the webpack config with customizations
    */
-  webpackConfig: string;
+  webpackConfig: string[] | string;
 }
 
 /**

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -113,6 +113,10 @@ export interface BuildWebpackServerSchema {
    * Use file name for lazy loaded chunks.
    */
   namedChunks?: boolean;
+  /**
+   * Script path containing a method to modify the webpack config with customizations
+   */
+  webpackConfig: string;
 }
 
 /**

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -152,6 +152,10 @@
         "type": "string"
       },
       "default": []
+    },
+    "webpackConfig": {
+      "type": "string",
+      "description": "Script path containing custom webpack config"
     }
   },
   "additionalProperties": false,

--- a/packages/angular_devkit/build_angular/src/server/schema.json
+++ b/packages/angular_devkit/build_angular/src/server/schema.json
@@ -154,8 +154,19 @@
       "default": []
     },
     "webpackConfig": {
-      "type": "string",
-      "description": "Script path containing custom webpack config"
+      "anyOf": [
+        {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "default": [],
+      "description": "Script path(s) containing a method to modify the webpack config with customizations"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
…nfig by providing a hook point / callback that receives the merged config and target name.

In angular.json one may specify "webpackConfig" as path to a JS script that receives the full webpack config object and returns the customized webpack config object.
Those 1% of users that have to modify the config can, the other 99% still can use the simple CLI as intended without ever beeing bugged by this feature.