### PR TITLE
feat(@schematics/angular): update tsconfig.json libs to include es2017

### DIFF
--- a/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
+++ b/packages/schematics/angular/library/files/__projectRoot__/tsconfig.lib.json
@@ -14,7 +14,7 @@
     "types": [],
     "lib": [
       "dom",
-      "es2015"
+      "es2017"
     ]
   },
   "angularCompilerOptions": {


### PR DESCRIPTION
Currently, libraries created using the schematic only use the `es2015` TypeScript lib. ECMAScript 2016, 2017 and 2018 have already been released. Interfaces introduced in these releases are unavailable in TypeScript without manually editing the `tsconfig.json`. This PR updates the `lib` property in `tsconfig.json` for Angular libraries to include at least `es2017`. This is an intermediate solution, until https://github.com/angular/devkit/pull/869 can be merged, which bumps the lib to `es2018`.