### PR TITLE
test(@angular-devkit/core): add missing parameter in angular-workspace.json

### DIFF
--- a/tests/@angular_devkit/core/workspace/angular-workspace.json
+++ b/tests/@angular_devkit/core/workspace/angular-workspace.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "newProjectRoot": "./projects",
+  "defaultProject": "app",
   "cli": {
     "$globalOverride": "${HOME}/.angular-cli.json",
     "schematics": {


### PR DESCRIPTION
In a6767dcc, a defaultProject was added to workspaceJson in workspace_spec, which hasn't been
synced with tests/@angular_devkit/workspace/angular-workspace.json as expected. This was breaking
the related tests with more than one project, like in #739.