### PR TITLE
feat(@angular-devkit/core): use the root project as default project by default

### DIFF
--- a/packages/angular_devkit/core/src/workspace/workspace.ts
+++ b/packages/angular_devkit/core/src/workspace/workspace.ts
@@ -140,6 +140,13 @@ export class Workspace {
     } else if (this.listProjectNames().length === 1) {
       // If there is only one project, return that one.
       return this.listProjectNames()[0];
+    } else {
+      const rootProjectEntry = Object.entries(this._workspace.projects).find(([name, project]) => {
+        return project.root.length === 0;
+      });
+      if (rootProjectEntry) {
+        return rootProjectEntry[0];
+      }
     }
 
     // Otherwise return null.

--- a/packages/angular_devkit/core/src/workspace/workspace_spec.ts
+++ b/packages/angular_devkit/core/src/workspace/workspace_spec.ts
@@ -203,6 +203,26 @@ describe('Workspace', () => {
     ).subscribe(undefined, done.fail, done);
   });
 
+  fit('gets default project when there is one at workspace root', (done) => {
+    const customWorkspaceJson: WorkspaceSchema = {
+      ...workspaceJson,
+      defaultProject: undefined,
+      projects: {
+        ...workspaceJson.projects,
+        root: {
+          root: '',
+          sourceRoot: 'src',
+          projectType: 'application',
+          prefix: 'root',
+        },
+      },
+    };
+    const workspace = new Workspace(root, host);
+    workspace.loadWorkspaceFromJson(customWorkspaceJson).pipe(
+      tap((ws) => expect(ws.getDefaultProjectName()).toEqual('root')),
+    ).subscribe(undefined, done.fail, done);
+  });
+
   it('gets default project returns null when there is none', (done) => {
     const customWorkspaceJson = { ...workspaceJson, defaultProject: undefined, projects: {} };
     const workspace = new Workspace(root, host);


### PR DESCRIPTION
If there isn't any defaultProject set, permit to use the "root project" (ie the one which
isn't in the `/projects/` folder) as the default project "by default" if it exists.

In my opinion, if Angular CLI permit to create a project at workspace's root even if their is other projects in the `/projects/` folder (especially as it does this by default when creating a new workspace), this "root project" should be, logically, the default project, as this is the one developers will look at first.