### PR TITLE
fix(@schematics/update): support upper unbounded ranges

### DIFF
--- a/packages/schematics/update/update/index.ts
+++ b/packages/schematics/update/update/index.ts
@@ -38,7 +38,9 @@ const peerCompatibleWhitelist: { [name: string]: PeerVersionTransform } = {
     while (!semver.gtr(major + '.0.0', range)) {
       major++;
       if (major >= 99) {
-        throw new SchematicsException(`Invalid range: ${JSON.stringify(range)}`);
+        // Use original range if it supports a major this high
+        // Range is most likely unbounded (e.g., >=5.0.0)
+        return range;
       }
     }
 


### PR DESCRIPTION
Some third party angular packages contained peer dependencies on `@angular/core` that contained unbounded upper ranges (i.e., `>=2.4.0` or `>=5.0.0`).  This case is now handled in the update logic.

Fixes: angular/angular-cli#10621