### PR TITLE
feat(@schematics/angular): use application name as title in AppComponent

### DIFF
--- a/packages/schematics/angular/application/other-files/app.component.spec.ts
+++ b/packages/schematics/angular/application/other-files/app.component.spec.ts
@@ -17,10 +17,10 @@ describe('AppComponent', () => {
     const app = fixture.debugElement.componentInstance;
     expect(app).toBeTruthy();
   }));
-  it(`should have as title '<%= prefix %>'`, async(() => {
+  it(`should have as title '<%= name %>'`, async(() => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('<%= prefix %>');
+    expect(app.title).toEqual('<%= name %>');
   }));
   it('should render title in a h1 tag', async(() => {
     const fixture = TestBed.createComponent(AppComponent);

--- a/packages/schematics/angular/application/other-files/app.component.ts
+++ b/packages/schematics/angular/application/other-files/app.component.ts
@@ -31,5 +31,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.<%= styleext %>']<% } %>
 })
 export class AppComponent {
-  title = '<%= prefix %>';
+  title = '<%= name %>';
 }


### PR DESCRIPTION
The current schematic creates a new AppComponent with the value of the title property set to `app` (the value of `prefix` in the schematic). 

With the support of multiple projects it makes more sense to use the app name, so if you run `ng generate application admin` the initial page will reflect that: `Welcome to admin`.