### PR TITLE
feat(@schematics/angular): use app as an alias for the application schematic

### DIFF
--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -19,6 +19,7 @@
       "schema": "./service-worker/schema.json"
     },
     "application": {
+      "aliases": [ "app" ],
       "factory": "./application",
       "schema": "./application/schema.json",
       "description": "Create an Angular application."


### PR DESCRIPTION
Currently, if you run `ng generate app admin`, you will receive this error:

```
Schematic "app" not found in collection "@schematics/angular".
```

This patch adds the alias `app` to the `application` schematic.