### PR TITLE
docs(aio): fix typo

### DIFF
--- a/packages/schematics/angular/application/files/src/environments/environment.ts
+++ b/packages/schematics/angular/application/files/src/environments/environment.ts
@@ -1,5 +1,5 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {


### PR DESCRIPTION
Old behavior:
comment on line 2 tells user to use incorrect flag `---prod`

New behavior:
comment on line 2 tells user to use correct flag `--prod`