### PR TITLE
fix(@schematics/angular): e2e should use the name

### DIFF
--- a/packages/schematics/angular/application/index.ts
+++ b/packages/schematics/angular/application/index.ts
@@ -275,7 +275,6 @@ export default function (options: ApplicationOptions): Rule {
       name: `${options.name}-e2e`,
       relatedAppName: options.name,
       rootSelector: appRootSelector,
-      prefix: options.prefix || 'app',
     };
     if (options.projectRoot !== undefined) {
       e2eOptions.projectRoot = 'e2e';

--- a/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
+++ b/packages/schematics/angular/e2e/files/src/app.e2e-spec.ts
@@ -9,6 +9,6 @@ describe('workspace-project App', () => {
 
   it('should display welcome message', () => {
     page.navigateTo();
-    expect(page.getParagraphText()).toEqual('Welcome to <%= prefix %>!');
+    expect(page.getParagraphText()).toEqual('Welcome to <%= relatedAppName %>!');
   });
 });

--- a/packages/schematics/angular/e2e/schema.d.ts
+++ b/packages/schematics/angular/e2e/schema.d.ts
@@ -23,8 +23,4 @@ export interface Schema {
      * The name of the app being tested.
      */
     relatedAppName: string;
-    /**
-     * The prefix to apply.
-     */
-    prefix?: string;
 }

--- a/packages/schematics/angular/e2e/schema.json
+++ b/packages/schematics/angular/e2e/schema.json
@@ -26,13 +26,6 @@
     "relatedAppName": {
       "description": "The name of the app being tested.",
       "type": "string"
-    },
-    "prefix": {
-      "type": "string",
-      "format": "html-selector",
-      "description": "The prefix to apply to generated selectors.",
-      "default": "app",
-      "alias": "p"
     }
   },
   "required": [


### PR DESCRIPTION
PR #906 updated the app schematics to display the name of the app in the title,
so the e2e test has to be fixed.
The prefix is now useless (it was introduced by #720 to fix the e2e test when it was using prefix),
and has been removed.

This a follow up to fix a regression introduced by #906 and released in 6.0.x