### PR TITLE
feat(@schematics/angular): add schematic for spec files

### DIFF
--- a/packages/schematics/angular/collection.json
+++ b/packages/schematics/angular/collection.json
@@ -83,6 +83,11 @@
       "description": "Create an Angular service.",
       "schema": "./service/schema.json"
     },
+    "spec": {
+      "factory": "./spec",
+      "description": "Create an Angular spec.",
+      "schema": "./spec/schema.json"
+    },
     "universal": {
       "factory": "./universal",
       "description": "Create an Angular universal app.",

--- a/packages/schematics/angular/spec/index.ts
+++ b/packages/schematics/angular/spec/index.ts
@@ -7,15 +7,15 @@
  */
 import { strings } from '@angular-devkit/core';
 import {
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  Tree,
   apply,
   filter,
   mergeWith,
   move,
-  Rule,
-  SchematicContext,
-  SchematicsException,
   template,
-  Tree,
   url,
 } from '@angular-devkit/schematics';
 import { getWorkspace } from '../utility/config';
@@ -39,16 +39,25 @@ export default function (options: PipeOptions): Rule {
 
     const parsedPath = parseName(options.path, options.name);
 
-    let [, name, type] = parsedPath.name.replace(/\.ts$/, '').match(/(.*)\.([^.]+)$/) || [null, null, null];
+    const [, name, type] = parsedPath.name.replace(/\.ts$/, '').match(/(.*)\.([^.]+)$/) || [
+      null,
+      null,
+      null,
+    ];
 
     if (!name || !type) {
       throw new SchematicsException(
-        `The provided name / file should look like name.type (e.g. component-name.component) or name.type.ts (e.g. component-name.component.ts).`
+        'The provided name / file should look like name.type (e.g. component-name.component)'
+        + ' or name.type.ts (e.g. component-name.component.ts).',
       );
     }
 
     if (!supportedTypes.includes(type)) {
-      throw new SchematicsException(`The type "${ type }" is not supported. Please use one of [${ supportedTypes.join(', ') }].`);
+      const ex = `The type "${ type }" is not supported. Please use one of [${
+        supportedTypes.join(', ')
+      }].`;
+
+      throw new SchematicsException(ex);
     }
 
     options.name = name;

--- a/packages/schematics/angular/spec/index.ts
+++ b/packages/schematics/angular/spec/index.ts
@@ -1,0 +1,69 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { strings } from '@angular-devkit/core';
+import {
+  apply,
+  filter,
+  mergeWith,
+  move,
+  Rule,
+  SchematicContext,
+  SchematicsException,
+  template,
+  Tree,
+  url,
+} from '@angular-devkit/schematics';
+import { getWorkspace } from '../utility/config';
+import { parseName } from '../utility/parse-name';
+import { Schema as PipeOptions } from './schema';
+
+const supportedTypes = ['component', 'directive', 'guard', 'service', 'pipe', 'module'];
+
+export default function (options: PipeOptions): Rule {
+  return (host: Tree, context: SchematicContext) => {
+    const workspace = getWorkspace(host);
+    if (!options.project) {
+      throw new SchematicsException('Option (project) is required.');
+    }
+    const project = workspace.projects[options.project];
+
+    if (options.path === undefined) {
+      const projectDirName = project.projectType === 'application' ? 'app' : 'lib';
+      options.path = `/${project.root}/src/${projectDirName}`;
+    }
+
+    const parsedPath = parseName(options.path, options.name);
+
+    let [, name, type] = parsedPath.name.replace(/\.ts$/, '').match(/(.*)\.([^.]+)$/) || [null, null, null];
+
+    if (!name || !type) {
+      throw new SchematicsException(
+        `The provided name / file should look like name.type (e.g. component-name.component) or name.type.ts (e.g. component-name.component.ts).`
+      );
+    }
+
+    if (!supportedTypes.includes(type)) {
+      throw new SchematicsException(`The type "${ type }" is not supported. Please use one of [${ supportedTypes.join(', ') }].`);
+    }
+
+    options.name = name;
+    options.path = parsedPath.path;
+
+    const templateSource = apply(url(`../${type}/files`), [
+      filter(path => path.endsWith('.spec.ts')),
+      template({
+        ...strings,
+        'if-flat': () => '',
+        ...options,
+      }),
+      move(parsedPath.path),
+    ]);
+
+    return mergeWith(templateSource)(host, context);
+  };
+}

--- a/packages/schematics/angular/spec/index_spec.ts
+++ b/packages/schematics/angular/spec/index_spec.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+import * as path from 'path';
+import { Schema as ApplicationOptions } from '../application/schema';
+import { Schema as WorkspaceOptions } from '../workspace/schema';
+import { Schema as SpecOptions } from './schema';
+
+
+describe('Spec Schematic', () => {
+  const schematicRunner = new SchematicTestRunner(
+    '@schematics/angular',
+    path.join(__dirname, '../collection.json'),
+  );
+
+  const defaultOptions: SpecOptions = {
+    name: '',
+    project: 'bar',
+  };
+
+  const workspaceOptions: WorkspaceOptions = {
+    name: 'workspace',
+    newProjectRoot: 'projects',
+    version: '6.0.0',
+  };
+
+  const appOptions: ApplicationOptions = {
+    name: 'bar',
+    inlineStyle: false,
+    inlineTemplate: false,
+    routing: false,
+    style: 'css',
+    skipTests: false,
+    skipPackageJson: false,
+  };
+
+  let appTree: UnitTestTree;
+
+  beforeEach(() => {
+    appTree = schematicRunner.runSchematic('workspace', workspaceOptions);
+    appTree = schematicRunner.runSchematic('application', appOptions, appTree);
+  });
+
+  function testCreatedSpec(schematic: string, options: any) {
+    let tree = schematicRunner.runSchematic(schematic, options, appTree);
+
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeFalsy();
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
+
+    tree = schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo.' + schematic }, tree);
+
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeTruthy();
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
+  }
+
+  it('should create a spec for module', () => {
+    testCreatedSpec('module', {
+      name: 'foo',
+      spec: false,
+      flat: false,
+      project: 'bar',
+    });
+  });
+
+  it('should create a spec for component', () => {
+    testCreatedSpec('component', {
+      name: 'foo',
+      inlineStyle: false,
+      inlineTemplate: false,
+      changeDetection: 'Default',
+      styleext: 'css',
+      spec: false,
+      export: false,
+      project: 'bar',
+    });
+  });
+
+  it('should create a spec for directive', () => {
+    testCreatedSpec('directive', {
+      name: 'foo',
+      spec: false,
+      export: false,
+      prefix: 'app',
+      flat: false,
+      project: 'bar',
+    });
+  });
+
+  it('should create a spec for service', () => {
+    testCreatedSpec('service', {
+      name: 'foo',
+      spec: false,
+      flat: false,
+      project: 'bar',
+    });
+  });
+
+  it('should create a spec for guard', () => {
+    testCreatedSpec('guard', {
+      name: 'foo/foo', // foo folder here because guard flat parameter is ignored...
+      spec: false,
+      flat: false,
+      project: 'bar',
+    });
+  });
+
+  it('should create a spec for pipe', () => {
+    testCreatedSpec('pipe', {
+      name: 'foo',
+      spec: false,
+      export: false,
+      flat: false,
+      project: 'bar',
+    });
+  });
+
+  it('should throw for not allowed types', () => {
+    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo' }, appTree)).toThrow();
+    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/service' }, appTree)).toThrow();
+    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo.abc' }, appTree)).toThrow();
+  });
+});

--- a/packages/schematics/angular/spec/index_spec.ts
+++ b/packages/schematics/angular/spec/index_spec.ts
@@ -46,18 +46,6 @@ describe('Spec Schematic', () => {
     appTree = schematicRunner.runSchematic('application', appOptions, appTree);
   });
 
-  function testCreatedSpec(schematic: string, options: any) {
-    let tree = schematicRunner.runSchematic(schematic, options, appTree);
-
-    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeFalsy();
-    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
-
-    tree = schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo.' + schematic }, tree);
-
-    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeTruthy();
-    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
-  }
-
   it('should create a spec for module', () => {
     testCreatedSpec('module', {
       name: 'foo',
@@ -66,6 +54,21 @@ describe('Spec Schematic', () => {
       project: 'bar',
     });
   });
+
+  function testCreatedSpec(schematic: string, targetOptions: { [prop: string]: string | boolean }) {
+    const options = { ...defaultOptions, name: 'foo/foo.' + schematic };
+    let tree = schematicRunner.runSchematic(schematic, targetOptions, appTree);
+
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeFalsy();
+    expect(tree.files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
+
+    tree = schematicRunner.runSchematic('spec', options, tree);
+
+    const files = tree.files;
+
+    expect(files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.spec.ts`)).toBeTruthy();
+    expect(files.includes(`/projects/bar/src/app/foo/foo.${ schematic }.ts`)).toBeTruthy();
+  }
 
   it('should create a spec for component', () => {
     testCreatedSpec('component', {
@@ -120,8 +123,16 @@ describe('Spec Schematic', () => {
   });
 
   it('should throw for not allowed types', () => {
-    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo' }, appTree)).toThrow();
-    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/service' }, appTree)).toThrow();
-    expect(() => schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo.abc' }, appTree)).toThrow();
+    expect(() => {
+      schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo' }, appTree);
+    }).toThrow();
+
+    expect(() => {
+      schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/service' }, appTree);
+    }).toThrow();
+
+    expect(() => {
+      schematicRunner.runSchematic('spec', { ...defaultOptions, name: 'foo/foo.abc' }, appTree);
+    }).toThrow();
   });
 });

--- a/packages/schematics/angular/spec/schema.d.ts
+++ b/packages/schematics/angular/spec/schema.d.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+export interface Schema {
+    /**
+     * The name of the pipe.
+     */
+    name: string;
+    /**
+     * The path to create the pipe.
+     */
+    path?: string;
+    /**
+     * The name of the project.
+     */
+    project?: string;
+    /**
+     * Flag to indicate if a dir is created.
+     */
+    flat?: boolean;
+    /**
+     * Specifies if a spec file is generated.
+     */
+    spec?: boolean;
+    /**
+     * Allows for skipping the module import.
+     */
+    skipImport?: boolean;
+    /**
+     * Allows specification of the declaring module.
+     */
+    module?: string;
+    /**
+     * Specifies if declaring module exports the pipe.
+     */
+    export?: boolean;
+}

--- a/packages/schematics/angular/spec/schema.json
+++ b/packages/schematics/angular/spec/schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "id": "SchematicsAngularSpec",
+  "title": "Angular Spec Options Schema",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "The name / filename of the spec target.",
+      "$default": {
+        "$source": "argv",
+        "index": 0
+      }
+    },
+    "path": {
+      "type": "string",
+      "format": "path",
+      "description": "The path to create the spec.",
+      "visible": false
+    },
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
add schematic for spec in order to allow @angular/cli users to recreate disabled / removed spec files

implement main part of https://github.com/angular/angular-cli/issues/7727