### PR TITLE
fix(@schematics/angular): fix invalid configuration in lint

### DIFF
--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -476,9 +476,15 @@ function extractProjectsConfig(
 
       const tsConfigs: string[] = [];
       const excludes: string[] = [];
+      let warnForLint = false;
       if (config && config.lint && Array.isArray(config.lint)) {
         config.lint.forEach(lint => {
-          tsConfigs.push(lint.project);
+          if (lint.project) {
+            tsConfigs.push(lint.project);
+          } else {
+            warnForLint = true;
+          }
+
           if (lint.exclude) {
             if (typeof lint.exclude === 'string') {
               excludes.push(lint.exclude);
@@ -487,6 +493,12 @@ function extractProjectsConfig(
             }
           }
         });
+      }
+
+      if (warnForLint) {
+        logger.warn(`
+          Lint without 'project' was not migrated which is not supported in Angular CLI 6.
+        `);
       }
 
       const removeDupes = (items: string[]) => items.reduce((newItems, item) => {


### PR DESCRIPTION
Fix the invalid configuration in old lint in `.angular-cli.json`, which makes the `ng update @angular/cli` get the error : `Cannot read property 'indexOf' of undefined`, like the angular/angular-cli#10903