### PR TITLE
Refactor dev server builder webpack config

### DIFF
--- a/packages/angular_devkit/build_angular/src/browser/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/browser/schema.d.ts
@@ -49,7 +49,7 @@ export interface BrowserBuilderSchema {
   /**
    * Replace files with other files in the build.
    */
-  fileReplacements: FileReplacements[];
+  fileReplacements: FileReplacement[];
 
   /**
    * Path where output will be placed.

--- a/packages/angular_devkit/build_angular/src/dev-server/index.ts
+++ b/packages/angular_devkit/build_angular/src/dev-server/index.ts
@@ -111,9 +111,7 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
       // Replace the assets in options with the normalized version.
       tap((assetPatternObjects => browserOptions.assets = assetPatternObjects)),
       concatMap(() => new Observable(obs => {
-        const browserBuilder = new BrowserBuilder(this.context);
-        const webpackConfig = browserBuilder.buildWebpackConfig(
-          root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
+        const webpackConfig = this.buildWebpackConfig(root, projectRoot, host, browserOptions);
         const statsConfig = getWebpackStatsConfig(browserOptions.verbose);
 
         let webpackDevServerConfig: WebpackDevServerConfigurationOptions;
@@ -231,6 +229,18 @@ export class DevServerBuilder implements Builder<DevServerBuilderOptions> {
         // Teardown logic. Close the server when unsubscribed from.
         return () => server.close();
       })));
+  }
+
+  buildWebpackConfig(
+    root: Path,
+    projectRoot: Path,
+    host: virtualFs.Host<fs.Stats>,
+    browserOptions: BrowserBuilderSchema
+  ) {
+    const browserBuilder = new BrowserBuilder(this.context);
+    const webpackConfig = browserBuilder.buildWebpackConfig(
+      root, projectRoot, host, browserOptions as NormalizedBrowserBuilderSchema);
+    return webpackConfig;
   }
 
   private _buildServerConfig(

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -5,7 +5,7 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
-import {FileReplacement} from '../browser/schema';
+import { FileReplacement } from '../browser/schema';
 
 export interface BuildWebpackServerSchema {
   /**

--- a/packages/angular_devkit/build_angular/src/server/schema.d.ts
+++ b/packages/angular_devkit/build_angular/src/server/schema.d.ts
@@ -5,6 +5,8 @@
  * Use of this source code is governed by an MIT-style license that can be
  * found in the LICENSE file at https://angular.io/license
  */
+import {FileReplacement} from '../browser/schema';
+
 export interface BuildWebpackServerSchema {
   /**
    * The name of the TypeScript configuration file.
@@ -72,7 +74,7 @@ export interface BuildWebpackServerSchema {
   /**
    * Replace files with other files in the build.
    */
-  fileReplacements: FileReplacements[];
+  fileReplacements: FileReplacement[];
   /**
    * Define the output filename cache-busting hashing mode.
    */


### PR DESCRIPTION
In order to be able to extend Builders, the webpack configuration needs to be overridable.
This pr make it possible to do that. (The same approach as the BrowserBuilder uses.)