### PR TITLE
fix(@schematics/angular): remove angularCli in Karma when updating

### DIFF
--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -78,6 +78,7 @@ function migrateKarmaConfiguration(config: CliConfig): Rule {
         content = content.replace(`{ pattern: './src/test.ts', watched: false }`, '');
         content = content.replace(`'./src/test.ts': ['@angular/cli'],`, '');
         content = content.replace(`'./src/test.ts': ['@angular/cli']`, '');
+        content = content.replace(/angularCli[^}]*},?/, '');
         // Replace 1.x plugin names.
         content = content.replace(/@angular\/cli/g, '@angular-devkit/build-angular');
         // Replace code coverage output path.

--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -682,6 +682,9 @@ describe('Migration to v6', () => {
         preprocessors: {
           './src/test.ts': ['@angular/cli']
         },
+        angularCli: {
+          environment: 'dev'
+        },
       `);
 
       tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
@@ -689,6 +692,7 @@ describe('Migration to v6', () => {
       const content = tree.readContent(karmaPath);
       expect(content).not.toContain(`{ pattern: './src/test.ts', watched: false }`);
       expect(content).not.toContain(`'./src/test.ts': ['@angular/cli']`);
+      expect(content).not.toMatch(/angularCli[^}]*},?/);
     });
   });
 


### PR DESCRIPTION
Fix angular/angular-cli#11012
Remove invalid property `angularCli` when updating from 1.x to 6.x