### PR TITLE
fix(@schematics/angular): use old config root to set root and sourceR…

### DIFF
--- a/packages/schematics/angular/migrations/update-6/index.ts
+++ b/packages/schematics/angular/migrations/update-6/index.ts
@@ -387,8 +387,8 @@ function extractProjectsConfig(
       }
 
       const project: JsonObject = {
-        root: '',
-        sourceRoot: 'src',
+        root: join(normalize(appRoot), '..'),
+        sourceRoot: appRoot,
         projectType: 'application',
       };
 
@@ -525,7 +525,7 @@ function extractProjectsConfig(
       }
       const e2eProject: JsonObject = {
         root: project.root,
-        sourceRoot: project.root,
+        sourceRoot: join(project.root as Path, 'e2e'),
         projectType: 'application',
       };
 

--- a/packages/schematics/angular/migrations/update-6/index_spec.ts
+++ b/packages/schematics/angular/migrations/update-6/index_spec.ts
@@ -509,6 +509,17 @@ describe('Migration to v6', () => {
         tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
         const project = getConfig(tree).projects.foo;
         expect(project.root).toEqual('');
+        expect(project.sourceRoot).toEqual('src');
+        expect(project.projectType).toEqual('application');
+      });
+
+      it('should set the project root values for a different root', () => {
+        baseConfig.apps[0].root = 'apps/app1/src';
+        tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
+        tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
+        const project = getConfig(tree).projects.foo;
+        expect(project.root).toEqual('apps/app1');
+        expect(project.sourceRoot).toEqual('apps/app1/src');
         expect(project.projectType).toEqual('application');
       });
 
@@ -631,9 +642,26 @@ describe('Migration to v6', () => {
       it('should set the project root values', () => {
         tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
         tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
-        const e2e = getConfig(tree).projects['foo-e2e'].architect.e2e;
-        expect(e2e.builder).toEqual('@angular-devkit/build-angular:protractor');
-        const options = e2e.options;
+        const e2eProject = getConfig(tree).projects['foo-e2e'];
+        expect(e2eProject.root).toBe('');
+        expect(e2eProject.sourceRoot).toBe('e2e');
+        const e2eOptions = e2eProject.architect.e2e;
+        expect(e2eOptions.builder).toEqual('@angular-devkit/build-angular:protractor');
+        const options = e2eOptions.options;
+        expect(options.protractorConfig).toEqual('./protractor.conf.js');
+        expect(options.devServerTarget).toEqual('foo:serve');
+      });
+
+      it('should set the project root values for a different root', () => {
+        baseConfig.apps[0].root = 'apps/app1/src';
+        tree.create(oldConfigPath, JSON.stringify(baseConfig, null, 2));
+        tree = schematicRunner.runSchematic('migration-01', defaultOptions, tree);
+        const e2eProject = getConfig(tree).projects['foo-e2e'];
+        expect(e2eProject.root).toBe('apps/app1');
+        expect(e2eProject.sourceRoot).toBe('apps/app1/e2e');
+        const e2eOptions = e2eProject.architect.e2e;
+        expect(e2eOptions.builder).toEqual('@angular-devkit/build-angular:protractor');
+        const options = e2eOptions.options;
         expect(options.protractorConfig).toEqual('./protractor.conf.js');
         expect(options.devServerTarget).toEqual('foo:serve');
       });


### PR DESCRIPTION
…oot during update-6

Within the update-6 migration, the `root` and `sourceRoot` are both hard coded. The previous `app.root` should be used. Similarly, the e2e project's `root` and `sourceRoot` were both set to the `project.root`. 

I made an assumption that the `sourceRoot` of the e2e project would be in a directory under the `root` called `e2e`. I'm not sure if that's a valid assumption but it seems more accurate than a hardcoded `''` and there is not much of a definite indicator.

Fixes https://github.com/angular/angular-cli/issues/10883