### PR TITLE
fix(@angular-devkit/schematics): include logger in testing context

### DIFF
--- a/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
+++ b/packages/angular_devkit/schematics/testing/schematic-test-runner.ts
@@ -149,7 +149,9 @@ export class SchematicTestRunner {
   }
 
   callRule(rule: Rule, tree: Tree, parentContext?: Partial<SchematicContext>): Observable<Tree> {
-    const context = this._engine.createContext({} as Schematic<{}, {}>, parentContext);
+    const defaultContext = {} as Schematic<{}, {}>;
+    defaultContext.logger = this._logger;
+    const context = this._engine.createContext(defaultContext, parentContext);
 
     return callRule(rule, observableOf(tree), context);
   }


### PR DESCRIPTION
SchematicTestRunner.callRule was not using the schematicTestRunner's `logger` requiring the user to pass it in the parent context themselves. This should be default.